### PR TITLE
Adding sse_kms_key optional parameter and using in Redshift UNLOAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,19 @@ for other options).</p>
 at the end of the command can be used, but that should cover most possible use cases.</p>
     </td>
  </tr>
+  <tr>
+    <td><tt>sse_kms_key</tt></td>
+    <td>No</td>
+    <td>No default</td>
+    <td>
+<p>The KMS key ID to use for server-side encryption in S3 during the Redshift <tt>UNLOAD</tt> operation rather than AWS's default
+encryption. The Redshift IAM role must have access to the KMS key for writing with it, and the Spark IAM role must have access
+to the key for read operations. Reading the encrypted data requires no changes (AWS handles this under-the-hood) so long as
+Spark's IAM role has the proper access.</p> 
+<p>See the <a href="https://docs.aws.amazon.com/redshift/latest/dg/t_unloading_encrypted_files.html">Redshift docs</a>
+for more information.</p>
+    </td>
+ </tr>
  <tr>
     <td><tt>tempformat</tt>  (Experimental)</td>
     <td>No</td>

--- a/src/main/scala/com/databricks/spark/redshift/Parameters.scala
+++ b/src/main/scala/com/databricks/spark/redshift/Parameters.scala
@@ -30,6 +30,7 @@ private[redshift] object Parameters {
     // * sortkeyspec has no default, but is optional
     // * distkey has no default, but is optional unless using diststyle KEY
     // * jdbcdriver has no default, but is optional
+    // * sse_kms_key has no default, but is optional
 
     "forward_spark_s3_credentials" -> "false",
     "tempformat" -> "AVRO",
@@ -285,5 +286,10 @@ private[redshift] object Parameters {
           new BasicSessionCredentials(accessKey, secretAccessKey, sessionToken))
       }
     }
+
+    /**
+     * The AWS SSE-KMS key to use for encryption during UNLOAD operations instead of AWS's default encryption
+     */
+    def sseKmsKey: Option[String] = parameters.get("sse_kms_key")
   }
 }


### PR DESCRIPTION
Adding new optional parameter `sse_kms_key` that is wired into the Redshift `UNLOAD` operation according to [AWS docs](https://docs.aws.amazon.com/redshift/latest/dg/t_unloading_encrypted_files.html)
