### PR TITLE
[CDP-1677] Downgrade spark-redshift-community driver to scala 2.11 and spark 2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,15 +22,15 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import sbtrelease.ReleasePlugin.autoImport._
 import scoverage.ScoverageKeys
 
-val sparkVersion = "3.0.2"
+val sparkVersion = "2.4.7"
 
 // Define a custom test configuration so that unit test helper classes can be re-used under
 // the integration tests configuration; see http://stackoverflow.com/a/20635808.
 lazy val IntegrationTest = config("it") extend Test
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
-val testHadoopVersion = sys.props.get("hadoop.testVersion").getOrElse("3.2.1")
+val testHadoopVersion = sys.props.get("hadoop.testVersion").getOrElse("2.9.2")
 // DON't UPGRADE AWS-SDK-JAVA if not compatible with hadoop version
-val testAWSJavaSDKVersion = sys.props.get("aws.testVersion").getOrElse("1.11.1033")
+val testAWSJavaSDKVersion = sys.props.get("aws.testVersion").getOrElse("1.11.199")
 
 
 lazy val root = Project("spark-redshift", file("."))
@@ -42,13 +42,13 @@ lazy val root = Project("spark-redshift", file("."))
   .settings(
     name := "spark-redshift",
     organization := "io.github.spark-redshift-community",
-    scalaVersion := "2.12.11",
+    scalaVersion := "2.11.12",
     licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"),
     credentials += Credentials(Path.userHome / ".sbt" / ".credentials"),
     scalacOptions ++= Seq("-target:jvm-1.8"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
-      "org.slf4j" % "slf4j-api" % "1.7.5",
+      "org.slf4j" % "slf4j-api" % "1.7.16",
       "com.eclipsesource.minimal-json" % "minimal-json" % "0.9.4",
 
       // A Redshift-compatible JDBC driver must be present on the classpath for spark-redshift to work.

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
@@ -24,6 +24,7 @@ import java.util.Locale
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.{Encoder, Row}
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.types._
 
@@ -135,7 +136,7 @@ private[redshift] object Conversions {
     // As a performance optimization, re-use the same mutable row / array:
     val converted: Array[Any] = Array.fill(schema.length)(null)
     val externalRow = new GenericRow(converted)
-    val toRow = RowEncoder(schema).createSerializer()
+    val encoder = RowEncoder(schema)
     (inputRow: Array[String]) => {
       var i = 0
       while (i < schema.length) {
@@ -152,7 +153,7 @@ private[redshift] object Conversions {
         }
         i += 1
       }
-      toRow.apply(externalRow)
+      encoder.toRow(externalRow)
     }
   }
 }

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -114,7 +114,7 @@ private[redshift] case class RedshiftRelation(
         if (results.next()) {
           val numRows = results.getLong(1)
           val parallelism = sqlContext.getConf("spark.sql.shuffle.partitions", "200").toInt
-          val emptyRow = RowEncoder(StructType(Seq.empty)).createSerializer().apply(Row(Seq.empty))
+          val emptyRow = RowEncoder(StructType(Seq.empty)).toRow(Row(Seq.empty))
           sqlContext.sparkContext
             .parallelize(1L to numRows, parallelism)
             .map(_ => emptyRow)

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
@@ -31,7 +31,7 @@ class ConversionsSuite extends FunSuite {
 
   private def createRowConverter(schema: StructType) = {
     Conversions.createRowConverter(schema, Parameters.DEFAULT_PARAMETERS("csvnullstring"))
-      .andThen(RowEncoder(schema).resolveAndBind().createDeserializer())
+      .andThen(RowEncoder(schema).resolveAndBind().fromRow)
   }
 
   test("Data should be correctly converted") {

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/FilterPushdownSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/FilterPushdownSuite.scala
@@ -28,11 +28,11 @@ class FilterPushdownSuite extends FunSuite {
   }
 
   test("buildWhereClause with no filters that can be pushed down") {
-    assert(buildWhereClause(StructType(Nil), Seq(AlwaysTrue, AlwaysTrue)) === "")
+    assert(buildWhereClause(StructType(Nil), Seq(NewFilter, NewFilter)) === "")
   }
 
   test("buildWhereClause with with some filters that cannot be pushed down") {
-    val whereClause = buildWhereClause(testSchema, Seq(EqualTo("test_int", 1), AlwaysTrue))
+    val whereClause = buildWhereClause(testSchema, Seq(EqualTo("test_int", 1), NewFilter))
     assert(whereClause === """WHERE "test_int" = 1""")
   }
 
@@ -88,4 +88,9 @@ class FilterPushdownSuite extends FunSuite {
     StructField("test_string", StringType),
     StructField("test_timestamp", TimestampType)))
 
+  /** A new filter subclasss which our pushdown logic does not know how to handle */
+  private case object NewFilter extends Filter {
+    override def references: Array[String] = Array.empty
+  }
 }
+

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
@@ -251,7 +251,7 @@ class RedshiftSourceSuite
     val rdd = relation.asInstanceOf[PrunedFilteredScan]
       .buildScan(Array("testbyte", "testbool"), Array.empty[Filter])
       .mapPartitions { iter =>
-        val fromRow = RowEncoder(resultSchema).resolveAndBind().createDeserializer().apply(_)
+        val fromRow = RowEncoder(resultSchema).resolveAndBind().fromRow _
         iter.asInstanceOf[Iterator[InternalRow]].map(fromRow)
       }
     val prunedExpectedValues = Array(
@@ -304,7 +304,7 @@ class RedshiftSourceSuite
     val rdd = relation.asInstanceOf[PrunedFilteredScan]
       .buildScan(Array("testbyte", "testbool"), filters)
       .mapPartitions { iter =>
-        val fromRow = RowEncoder(resultSchema).resolveAndBind().createDeserializer().apply(_)
+        val fromRow = RowEncoder(resultSchema).resolveAndBind().fromRow _
         iter.asInstanceOf[Iterator[InternalRow]].map(fromRow)
       }
 
@@ -341,7 +341,7 @@ class RedshiftSourceSuite
     val rdd = relation.asInstanceOf[PrunedFilteredScan]
       .buildScan(Array("testbyte", "testbool"), Array.empty[Filter])
       .mapPartitions { iter =>
-        val fromRow = RowEncoder(resultSchema).resolveAndBind().createDeserializer().apply(_)
+        val fromRow = RowEncoder(resultSchema).resolveAndBind().fromRow _
         iter.asInstanceOf[Iterator[InternalRow]].map(fromRow)
       }
     val prunedExpectedValues = Array(
@@ -658,23 +658,23 @@ class RedshiftSourceSuite
 
   test("Saves throw error message if S3 Block FileSystem would be used") {
     val params = defaultParams + ("tempdir" -> defaultParams("tempdir").replace("s3a", "s3"))
-    val e = intercept[UnsupportedFileSystemException] {
+    val e = intercept[IllegalArgumentException] {
       expectedDataDF.write
         .format("io.github.spark_redshift_community.spark.redshift")
         .mode("append")
         .options(params)
         .save()
     }
-    assert(e.getMessage.contains("No FileSystem for scheme"))
+    assert(e.getMessage.contains("Block FileSystem"))
   }
 
   test("Loads throw error message if S3 Block FileSystem would be used") {
     val params = defaultParams + ("tempdir" -> defaultParams("tempdir").replace("s3a", "s3"))
-    val e = intercept[UnsupportedFileSystemException] {
+    val e = intercept[IllegalArgumentException] {
       testSqlContext.read.format("io.github.spark_redshift_community.spark.redshift")
         .options(params)
         .load()
     }
-    assert(e.getMessage.contains("No FileSystem for scheme"))
+    assert(e.getMessage.contains("Block FileSystem"))
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.4"
+version in ThisBuild := "5.1.0-aiq1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq1"
+version in ThisBuild := "5.0.4-aiq1"


### PR DESCRIPTION
The `spark-redshift-community` branch is copy of master from https://github.com/spark-redshift-community/spark-redshift. Then I downgraded the following libs:

- scala to 2.11
- spark to 2.4
- hadoop to 2.9 (technically we use our forked https://github.com/ActionIQ/hadoop but its just for compile)

Then I reverted the 2.4 API changes.

## Test Notes
```
mitesh@spark-redshift (Scala211Spark24) > sbt test
[info] Tests: succeeded 67, failed 0, canceled 0, ignored 6, pending 0
[info] All tests passed.
```

## Deploy Notes
```
sbt publishM2
aws s3 sync ~/.m2/repository/io/github/spark-redshift-community/ s3://aiq-artifacts/releases/io/github/spark-redshift-community
```