### PR TITLE
[EXE-1273] Extra pushdown & Unload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,7 @@ lazy val root = Project("spark-redshift", file("."))
       // A Redshift-compatible JDBC driver must be present on the classpath for spark-redshift to work.
       // For testing, we use an Amazon driver, which is available from
       // http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html
-      "com.amazon.redshift" % "jdbc41" % "1.2.27.1051" % "test" from "https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/1.2.27.1051/RedshiftJDBC41-no-awssdk-1.2.27.1051.jar",
-
+      "com.amazon.redshift" % "jdbc42" % "2.1.0.14" % "test" from "https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.14/redshift-jdbc42-2.1.0.14.jar",
       "com.google.guava" % "guava" % "27.0.1-jre" % "test",
       "org.scalatest" %% "scalatest" % "3.0.5" % "test",
       "org.mockito" % "mockito-core" % "1.10.19" % "test",

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
@@ -27,8 +27,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
-
 /**
  * Redshift Source implementation for Spark SQL
  */

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
@@ -48,15 +48,9 @@ class DefaultSource(
 
   private def appendRedshiftPushDownStrategy(
     sqlContext: SQLContext,
-    jdbcOptions: JDBCOptions
   ): Unit = {
-    val extraPushdown = jdbcOptions
-      .asProperties
-      .asScala
-      .get("redshift_extra_pushdown")
-      .exists(_.toBoolean)
     sqlContext.sparkSession.experimental.extraStrategies ++= Seq(
-      new RedshiftPushDownStrategy(extraPushdown)
+      new RedshiftPushDownStrategy(sqlContext.sparkContext.getConf)
     )
   }
   /**
@@ -68,7 +62,7 @@ class DefaultSource(
       parameters: Map[String, String]): BaseRelation = {
     val params = Parameters.mergeParameters(parameters)
     val jdbcOptions = new JDBCOptions(CaseInsensitiveMap(parameters))
-    appendRedshiftPushDownStrategy(sqlContext, jdbcOptions)
+    appendRedshiftPushDownStrategy(sqlContext)
     redshift.RedshiftRelation(jdbcWrapper, s3ClientFactory, params, None, jdbcOptions)(sqlContext)
   }
 
@@ -81,7 +75,7 @@ class DefaultSource(
       schema: StructType): BaseRelation = {
     val params = Parameters.mergeParameters(parameters)
     val jdbcOptions = new JDBCOptions(CaseInsensitiveMap(parameters))
-    appendRedshiftPushDownStrategy(sqlContext, jdbcOptions)
+    appendRedshiftPushDownStrategy(sqlContext)
     redshift.RedshiftRelation(jdbcWrapper,
       s3ClientFactory,
       params,

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCPushdownWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCPushdownWrapper.scala
@@ -96,10 +96,9 @@ object RedshiftPushDownSqlStatement {
 // scalastyle:off
 // https://stackoverflow.com/questions/2265503/why-do-i-need-to-override-the-equals-and-hashcode-methods-in-java
 private[redshift] class RedshiftPushDownSqlStatement(
-                                          val numOfVar: Int = 0,
-                                          val list: List[StatementElement] = Nil
-                                        )
-  extends Serializable {
+  val numOfVar: Int = 0,
+  val list: List[StatementElement] = Nil
+) extends Serializable {
   def +(element: StatementElement): RedshiftPushDownSqlStatement =
     new RedshiftPushDownSqlStatement(numOfVar + element.isVariable, element :: list)
 

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCPushdownWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCPushdownWrapper.scala
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off line.size.limit
+// https://github.com/ActionIQ-OSS/spark-snowflake/blob/spark_2.4/src/main/scala/net/snowflake/spark/snowflake/SnowflakeJDBCWrapper.scala
+// scalastyle:on line.size.limit
+
+package io.github.spark_redshift_community.spark.redshift
+
+import scala.collection.mutable.ListBuffer
+
+private[redshift] case class ConstantString(override val value: String)
+  extends StatementElement
+
+private[redshift] object ConstantStringVal {
+  def apply(l: Any): StatementElement = {
+    if (l == null || l.toString.toLowerCase == "null") {
+      ConstantString("NULL")
+    } else {
+      ConstantString(l.toString)
+    }
+  }
+}
+
+sealed trait StatementElement {
+
+  val value: String
+
+  val isVariable: Int = 0
+
+  def +(element: StatementElement): RedshiftPushDownSqlStatement =
+    new RedshiftPushDownSqlStatement(
+      isVariable + element.isVariable,
+      element :: List[StatementElement](this)
+    )
+
+  def +(statement: RedshiftPushDownSqlStatement): RedshiftPushDownSqlStatement =
+    new RedshiftPushDownSqlStatement(
+      isVariable + statement.numOfVar,
+      statement.list ::: List[StatementElement](this)
+    )
+
+  def +(str: String): RedshiftPushDownSqlStatement = this + ConstantString(str)
+
+  override def toString: String = value
+
+  def ! : RedshiftPushDownSqlStatement = toStatement
+
+  def toStatement: RedshiftPushDownSqlStatement =
+    new RedshiftPushDownSqlStatement(isVariable, List[StatementElement](this))
+
+  def sql: String = value
+}
+
+object RedshiftPushDownSqlStatement {
+  // FOR TESTING ONLY!
+  val capturedQueries = ListBuffer.empty[String]
+}
+
+// scalastyle:off
+// https://stackoverflow.com/questions/2265503/why-do-i-need-to-override-the-equals-and-hashcode-methods-in-java
+private[redshift] class RedshiftPushDownSqlStatement(
+                                          val numOfVar: Int = 0,
+                                          val list: List[StatementElement] = Nil
+                                        )
+  extends Serializable {
+  def +(element: StatementElement): RedshiftPushDownSqlStatement =
+    new RedshiftPushDownSqlStatement(numOfVar + element.isVariable, element :: list)
+
+  def +(statement: RedshiftPushDownSqlStatement): RedshiftPushDownSqlStatement =
+    new RedshiftPushDownSqlStatement(
+      numOfVar + statement.numOfVar,
+      statement.list ::: list
+    )
+
+  def +(str: String): RedshiftPushDownSqlStatement = this + ConstantString(str)
+
+  def isEmpty: Boolean = list.isEmpty
+
+  override def equals(obj: scala.Any): Boolean =
+    obj match {
+      case other: RedshiftPushDownSqlStatement =>
+        if (this.statementString == other.statementString) true else false
+      case _ => false
+    }
+
+  override def toString: String = {
+    val buffer = new StringBuilder
+    val sql = list.reverse
+
+    sql.foreach {
+      case x: ConstantString =>
+        if (buffer.nonEmpty && buffer.last != ' ') {
+          buffer.append(" ")
+        }
+        buffer.append(x)
+      case x: VariableElement[_] =>
+        if (buffer.nonEmpty && buffer.last != ' ') {
+          buffer.append(" ")
+        }
+        buffer.append(x.sql)
+    }
+
+    buffer.toString()
+  }
+
+  def statementString: String = {
+    val buffer = new StringBuilder
+    val sql = list.reverse
+
+    sql.foreach {
+      case x: ConstantString =>
+        if (buffer.nonEmpty && buffer.last != ' ') {
+          buffer.append(" ")
+        }
+        buffer.append(x)
+      case x: VariableElement[_] =>
+        if (buffer.nonEmpty && buffer.last != ' ') {
+          buffer.append(" ")
+        }
+        buffer.append(x.value)
+        buffer.append("(")
+        buffer.append(x.variable)
+        buffer.append(")")
+    }
+
+    buffer.toString()
+  }
+}
+// scalastyle:on
+
+private[redshift] sealed trait VariableElement[T] extends StatementElement {
+  override val value = "?"
+
+  override val isVariable: Int = 1
+
+  val variable: Option[T]
+
+  override def sql: String = if (variable.isDefined) variable.get.toString else "NULL"
+
+}
+
+private[redshift] case class Identifier(name: String)
+  extends VariableElement[String] {
+  override val variable = Some(name)
+  override val value: String = "identifier(?)"
+}
+
+private[redshift] case class StringVariable(override val variable: Option[String])
+  extends VariableElement[String] {
+  override def sql: String = if (variable.isDefined) s"""'${variable.get}'""" else "NULL"
+}
+
+private[redshift] case class IntVariable(override val variable: Option[Int])
+  extends VariableElement[Int]
+
+private[redshift] case class LongVariable(override val variable: Option[Long])
+  extends VariableElement[Long]
+
+private[redshift] case class ShortVariable(override val variable: Option[Short])
+  extends VariableElement[Short]
+
+private[redshift] case class FloatVariable(override val variable: Option[Float])
+  extends VariableElement[Float]
+
+private[redshift] case class DoubleVariable(override val variable: Option[Double])
+  extends VariableElement[Double]
+
+private[redshift] case class BooleanVariable(override val variable: Option[Boolean])
+  extends VariableElement[Boolean]
+
+private[redshift] case class ByteVariable(override val variable: Option[Byte])
+  extends VariableElement[Byte]

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -22,7 +22,6 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 import com.eclipsesource.json.Json
 import io.github.spark_redshift_community.spark.redshift.Parameters.MergedParameters
-import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -109,9 +109,10 @@ private[redshift] case class RedshiftRelation(
     }
   }
 
-  private def executeUnloadQuery(query: String,
-                                 schema: StructType
-                                ): RDD[InternalRow] = {
+  private def executeUnloadQuery(
+    query: String,
+    schema: StructType
+  ): RDD[InternalRow] = {
     // Unload data from Redshift into a temporary directory in S3:
     val tempDir = params.createPerQueryTempDir()
     val unloadSql = buildUnloadStmt(query, tempDir, creds, params.sseKmsKey)
@@ -173,8 +174,10 @@ private[redshift] case class RedshiftRelation(
     Utils.checkThatBucketHasObjectLifecycleConfiguration(params.rootTempDir, s3ClientFactory(creds))
   }
 
-  def buildRDDFromSQL(statement: RedshiftPushDownSqlStatement,
-                      schema: StructType): RDD[InternalRow] = {
+  def buildRDDFromSQL(
+    statement: RedshiftPushDownSqlStatement,
+    schema: StructType
+  ): RDD[InternalRow] = {
     val queryString = statement.toString
     log.info(s"Executing query with extra pushdown ${queryString} in redshift")
     if (queryString.contains("COUNT(")) {
@@ -186,8 +189,7 @@ private[redshift] case class RedshiftRelation(
     }
   }
 
-  override def buildScan(requiredColumns: Array[String], filters: Array[Filter])
-  : RDD[Row] = {
+  override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
     checkS3Setting()
     if (requiredColumns.isEmpty) {
       // In the special case where no columns were requested, issue a `count(*)` against Redshift
@@ -214,10 +216,11 @@ private[redshift] case class RedshiftRelation(
   override def needConversion: Boolean = false
 
   private def buildUnloadStmt(
-      query: String,
-      tempDir: String,
-      creds: AWSCredentialsProvider,
-      sseKmsKey: Option[String]): String = {
+    query: String,
+    tempDir: String,
+    creds: AWSCredentialsProvider,
+    sseKmsKey: Option[String]
+  ): String = {
     val credsString: String =
       AWSCredentialsUtils.getRedshiftCredentialsString(params, creds.getCredentials)
     // We need to remove S3 credentials from the unload path URI because they will conflict with

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -228,7 +228,7 @@ private[redshift] case class RedshiftRelation(
     val unloadQuery = s"UNLOAD ('$query') TO '$fixedUrl' WITH CREDENTIALS '$credsString'" +
       s" ESCAPE MANIFEST NULL AS '${params.nullString}'" +
       s" $sseKmsClause"
-    val finalQuery = RedshiftPushDownSqlStatement.appendTagsToQuery(jdbcOptions, query)
+    val finalQuery = RedshiftPushDownSqlStatement.appendTagsToQuery(jdbcOptions, unloadQuery)
     log.info(finalQuery)
     finalQuery
   }

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownPlan.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownPlan.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off line.size.limit
+// https://github.com/ActionIQ-OSS/spark-snowflake/blob/spark_2.4/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakePlan.scala
+// scalastyle:on line.size.limit
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.types.{StructField, StructType}
+
+case class RedshiftPushDownPlan(output: Seq[Attribute], rdd: RDD[InternalRow]) extends SparkPlan {
+  override def children: Seq[SparkPlan] = Nil
+  protected override def doExecute(): RDD[InternalRow] = {
+
+    val schema = StructType(
+      output.map(attr => StructField(attr.name, attr.dataType, attr.nullable))
+    )
+
+    rdd.mapPartitions { iter =>
+      val project = UnsafeProjection.create(schema)
+      iter.map(project)
+    }
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownStrategy.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownStrategy.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off line.size.limit
+// https://github.com/ActionIQ-OSS/spark-snowflake/blob/spark_2.4/src/main/scala/net/snowflake/spark/snowflake/pushdowns/SnowflakeStrategy.scala
+// scalastyle:on line.size.limit
+package io.github.spark_redshift_community.spark.redshift.pushdowns
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Strategy
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.execution.SparkPlan
+import io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration.QueryBuilder
+import org.apache.spark.sql.catalyst.InternalRow
+
+// Entry point of the pushdowns, taking in a logical plan and returns a spark physical plan.
+class RedshiftPushDownStrategy(extraPushdown: Boolean) extends Strategy {
+
+  def apply(plan: LogicalPlan): Seq[SparkPlan] = {
+    if (extraPushdown) {
+      try {
+        buildQuery(plan.transform({
+          case Project(Nil, child) => child
+          case SubqueryAlias(_, child) => child
+        })).getOrElse(Nil)
+      } catch {
+        case e: Exception =>
+          log.warn(s"Pushdown failed: ${e.getMessage}")
+          Nil
+      }
+    } else {
+      Nil
+    }
+  }
+
+  private def buildQuery(plan: LogicalPlan): Option[Seq[RedshiftPushDownPlan]] = {
+    QueryBuilder.getRDDFromPlan(plan).map {
+      case (output: Seq[Attribute], rdd: RDD[InternalRow]) =>
+        Seq(RedshiftPushDownPlan(output, rdd))
+    }
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownStrategy.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownStrategy.scala
@@ -26,13 +26,14 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.SparkPlan
 import io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration.QueryBuilder
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.InternalRow
 
 // Entry point of the pushdowns, taking in a logical plan and returns a spark physical plan.
-class RedshiftPushDownStrategy(extraPushdown: Boolean) extends Strategy {
+class RedshiftPushDownStrategy(conf: SparkConf) extends Strategy {
 
   def apply(plan: LogicalPlan): Seq[SparkPlan] = {
-    if (extraPushdown) {
+    if (conf.get("spark.aiq.sql.enable_jdbc_pushdown", "false").toBoolean) {
       try {
         buildQuery(plan.transform({
           case Project(Nil, child) => child

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/AggregationStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/AggregationStatement.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate._
+
+import io.github.spark_redshift_community.spark.redshift._
+
+private[querygeneration] object AggregationStatement {
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    expr match {
+      case _: AggregateExpression =>
+        // Take only the first child, as all of the functions below have only one.
+        expr.children.headOption.flatMap(agg_fun => {
+          Option(agg_fun match {
+            case _: Average | _: Corr | _: CovPopulation | _: CovSample | _: Count |
+                 _: Max | _: Min | _: Sum | _: StddevPop | _: StddevSamp |
+                 _: VariancePop | _: VarianceSamp =>
+              val distinct: RedshiftPushDownSqlStatement =
+                if (expr.sql contains "(DISTINCT ") ConstantString("DISTINCT") !
+                else new RedshiftPushDownSqlStatement()
+
+              ConstantString(agg_fun.prettyName.toUpperCase) +
+                blockStatement(
+                  distinct + convertStatements(fields, agg_fun.children: _*)
+                )
+            case _ =>
+              // This exception is not a real issue. It will be caught in
+              // QueryBuilder.
+              throw new IllegalArgumentException(
+                "not supported"
+              )
+          })
+        })
+      case _ => None
+    }
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/BasicStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/BasicStatement.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{
+  And,
+  Attribute,
+  BinaryOperator,
+  BitwiseAnd,
+  BitwiseNot,
+  BitwiseOr,
+  BitwiseXor,
+  EqualNullSafe,
+  Expression,
+  Literal,
+  Or
+}
+import org.apache.spark.sql.types._
+
+import io.github.spark_redshift_community.spark.redshift._
+
+
+private[querygeneration] object BasicStatement {
+
+  /** Used mainly by QueryGeneration.convertExpression. This matches
+  * a tuple of (Expression, Seq[Attribute]) representing the expression to
+  * be matched and the fields that define the valid fields in the current expression
+  * scope, respectively.
+  *
+  * @param expAttr A pair-tuple representing the expression to be matched and the
+  *                attribute fields.
+  * @return An option containing the translated SQL, if there is a match, or None if there
+  *         is no match.
+  */
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    Option(expr match {
+      case a: Attribute => addAttributeStatement(a, fields)
+      case And(left, right) =>
+        blockStatement(
+          convertStatement(left, fields) + "AND" + convertStatement(
+            right,
+            fields
+          )
+        )
+      case Or(left, right) =>
+        blockStatement(
+          convertStatement(left, fields) + "OR" + convertStatement(
+            right,
+            fields
+          )
+        )
+      case BitwiseAnd(left, right) =>
+        ConstantString("BITAND") + blockStatement(
+          convertStatements(fields, left, right)
+        )
+      case BitwiseOr(left, right) =>
+        ConstantString("BITOR") + blockStatement(
+          convertStatements(fields, left, right)
+        )
+      case BitwiseXor(left, right) =>
+        ConstantString("BITXOR") + blockStatement(
+          convertStatements(fields, left, right)
+        )
+      case BitwiseNot(child) =>
+        ConstantString("BITNOT") + blockStatement(
+          convertStatement(child, fields)
+        )
+      case EqualNullSafe(left, right) =>
+        ConstantString("EQUAL_NULL") + blockStatement(
+          convertStatements(fields, left, right)
+        )
+      case b: BinaryOperator =>
+        blockStatement(
+          convertStatement(b.left, fields) + b.symbol + convertStatement(
+            b.right,
+            fields
+          )
+        )
+      case l: Literal =>
+        l.dataType match {
+          case StringType =>
+            if (l == null || l.toString() == "null") {
+              ConstantString("NULL") !
+            } else {
+              StringVariable(Some(l.toString())) ! // else "'" + str + "'"
+            }
+          case DateType =>
+            ConstantString("DATEADD(day,") + IntVariable(
+              Option(l.value).map(_.asInstanceOf[Int])
+            ) +
+              ", TO_DATE('1970-01-01'))" // s"DATEADD(day, ${l.value}, TO_DATE('1970-01-01'))"
+          case TimestampType =>
+            ConstantString("to_timestamp_ntz(") + l.toString() + ", 6)"
+          case _ =>
+            l.value match {
+              case v: Int => IntVariable(Some(v)) !
+              case v: Long => LongVariable(Some(v)) !
+              case v: Short => ShortVariable(Some(v)) !
+              case v: Boolean => BooleanVariable(Some(v)) !
+              case v: Float => FloatVariable(Some(v)) !
+              case v: Double => DoubleVariable(Some(v)) !
+              case v: Byte => ByteVariable(Some(v)) !
+              case _ => ConstantStringVal(l.value) !
+            }
+        }
+
+      case _ => null
+    })
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/BinaryOp.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/BinaryOp.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.plans.logical.{
+  BinaryNode,
+  Join,
+  LogicalPlan
+}
+
+/** Extractor for binary logical operations (e.g., joins). */
+private[querygeneration] object BinaryOp {
+
+  def unapply(node: BinaryNode): Option[(LogicalPlan, LogicalPlan)] =
+    Option(node match {
+      case _: Join => (node.left, node.right)
+      case _ => null
+    })
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/BooleanStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/BooleanStatement.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Contains, EndsWith, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, Not, StartsWith}
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.unsafe.types.UTF8String
+
+import io.github.spark_redshift_community.spark.redshift._
+
+/** Extractor for boolean expressions (return true or false). */
+private[querygeneration] object BooleanStatement {
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    Option(expr match {
+      case In(child, list) if list.forall(_.isInstanceOf[Literal]) =>
+        convertStatement(child, fields) + "IN" +
+          blockStatement(convertStatements(fields, list: _*))
+      case IsNull(child) =>
+        blockStatement(convertStatement(child, fields) + "IS NULL")
+      case IsNotNull(child) =>
+        blockStatement(convertStatement(child, fields) + "IS NOT NULL")
+      case Not(child) =>
+        child match {
+          case EqualTo(left, right) =>
+            blockStatement(
+              convertStatement(left, fields) + "!=" +
+                convertStatement(right, fields)
+            )
+          // NOT ( GreaterThanOrEqual, LessThanOrEqual,
+          // GreaterThan and LessThan ) have been optimized by spark
+          // and are handled by BinaryOperator in BasicStatement.
+          case GreaterThanOrEqual(left, right) =>
+            convertStatement(LessThan(left, right), fields)
+          case LessThanOrEqual(left, right) =>
+            convertStatement(GreaterThan(left, right), fields)
+          case GreaterThan(left, right) =>
+            convertStatement(LessThanOrEqual(left, right), fields)
+          case LessThan(left, right) =>
+            convertStatement(GreaterThanOrEqual(left, right), fields)
+          case _ =>
+            ConstantString("NOT") +
+              blockStatement(convertStatement(child, fields))
+        }
+      case Contains(child, Literal(pattern: UTF8String, StringType)) =>
+        convertStatement(child, fields) + "LIKE" + s"'%${pattern.toString}%'"
+      case EndsWith(child, Literal(pattern: UTF8String, StringType)) =>
+        convertStatement(child, fields) + "LIKE" + s"'%${pattern.toString}'"
+      case StartsWith(child, Literal(pattern: UTF8String, StringType)) =>
+        convertStatement(child, fields) + "LIKE" + s"'${pattern.toString}%'"
+
+      case _ => null
+    })
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/DateStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/DateStatement.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{AddMonths, Attribute, DateAdd, DateSub, Expression, Month, Quarter, TruncDate, TruncTimestamp, Year}
+
+import io.github.spark_redshift_community.spark.redshift._
+
+/** Extractor for boolean expressions (return true or false). */
+private[querygeneration] object DateStatement {
+  // DateAdd's pretty name in Spark is "date_add",
+  // the counterpart's name in SF is "DATEADD".
+  // And the syntax is some different.
+  val DATEADD = "DATEADD"
+
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    Option(expr match {
+      case DateAdd(startDate, days) =>
+        ConstantString(DATEADD) +
+          blockStatement(
+            ConstantString("day,") +
+              convertStatement(days, fields) + "," +
+              convertStatement(startDate, fields)
+          )
+
+      // To be tested
+      case DateSub(startDate, days) =>
+        ConstantString(DATEADD) +
+          blockStatement(
+            ConstantString("day, (0 - (") +
+              convertStatement(days, fields) + ") )," +
+              convertStatement(startDate, fields)
+          )
+
+      // Add AddMonths() support here
+      // But, Spark 3.0, it doesn't. For example,
+      // On spark 2.3/2.4, "2015-02-28" +1 month -> "2015-03-31"
+      // On spark 3.0,     "2015-02-28" +1 month -> "2015-03-28"
+      case AddMonths(_, _) => null
+
+      case _: Month | _: Quarter | _: Year |
+           _: TruncDate | _: TruncTimestamp =>
+        ConstantString(expr.prettyName.toUpperCase) +
+          blockStatement(convertStatements(fields, expr.children: _*))
+
+      case _ => null
+    })
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/MiscStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/MiscStatement.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, Attribute, CaseWhen, Cast, Coalesce, Descending, Expression, If, In, InSet, Literal, MakeDecimal, ScalarSubquery, ShiftLeft, ShiftRight, SortOrder, UnscaledValue}
+import org.apache.spark.sql.types.{Decimal, _}
+import org.apache.spark.unsafe.types.UTF8String
+
+import io.github.spark_redshift_community.spark.redshift._
+
+/** Extractors for everything else. */
+private[querygeneration] object MiscStatement {
+
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    Option(expr match {
+      case Alias(child: Expression, name: String) =>
+        blockStatement(convertStatement(child, fields), name)
+      case Cast(child, t, _) =>
+        getCastType(t) match {
+          case Some(cast) =>
+            (child.dataType, t) match {
+              case (_: DateType | _: TimestampType,
+              _: IntegerType | _: LongType | _: FloatType | _: DoubleType | _: DecimalType) => {
+                // This exception will not break the connector. It will be caught in
+                // QueryBuilder.
+                throw new IllegalArgumentException(
+                  s"Don't support to convert ${child.dataType} column to $t type"
+                  )
+              }
+              case _ =>
+            }
+            child.dataType match {
+              case (_: BooleanType) =>
+                blockStatement(ConstantString("case when")
+                  + convertStatement(child, fields) + "then 'True' else 'False' End")
+              case _ =>
+                ConstantString("CAST") +
+                  blockStatement(convertStatement(child, fields) + "AS" + cast)
+            }
+          case _ => convertStatement(child, fields)
+        }
+      case If(child, trueValue, falseValue) =>
+        ConstantString("IFF") +
+          blockStatement(
+            convertStatements(fields, child, trueValue, falseValue)
+          )
+
+      case In(child, list) =>
+        blockStatement(
+          convertStatement(child, fields) + "IN" +
+            blockStatement(convertStatements(fields, list: _*))
+        )
+
+      case InSet(child, hset) =>
+        convertStatement(In(child, setToExpr(hset)), fields)
+
+      // The 4th parameter is new from spark 3.0
+      case MakeDecimal(child, precision, scale) =>
+        ConstantString("TO_DECIMAL") + blockStatement(
+          blockStatement(
+            convertStatement(child, fields) + "/ POW(10," +
+              IntVariable(Some(scale)) + ")"
+          ) + "," + IntVariable(Some(precision)) + "," +
+            IntVariable(Some(scale))
+        )
+      case ShiftLeft(col, num) =>
+        ConstantString("BITSHIFTLEFT") +
+          blockStatement(convertStatements(fields, col, num))
+
+      case ShiftRight(col, num) =>
+        ConstantString("BITSHIFTRIGHT") +
+          blockStatement(convertStatements(fields, col, num))
+
+      case SortOrder(child, Ascending, _, _) =>
+        blockStatement(convertStatement(child, fields)) + "ASC"
+      case SortOrder(child, Descending, _, _) =>
+        blockStatement(convertStatement(child, fields)) + "DESC"
+
+      case ScalarSubquery(subquery, _, _) =>
+        blockStatement(new QueryBuilder(subquery).statement)
+
+      case UnscaledValue(child) =>
+        child.dataType match {
+          case d: DecimalType =>
+            blockStatement(
+              convertStatement(child, fields) + "* POW(10," + IntVariable(
+                Some(d.scale)
+              ) + ")"
+            )
+          case _ => null
+        }
+
+      case CaseWhen(branches, elseValue) =>
+        ConstantString("CASE") +
+          mkStatement(branches.map(conditionValue => {
+            ConstantString("WHEN") + convertStatement(conditionValue._1, fields) +
+              ConstantString("THEN") + convertStatement(conditionValue._2, fields)
+          }
+          ), " ") + { elseValue match {
+          case Some(value) => ConstantString("ELSE") + convertStatement(value, fields)
+          case None => new RedshiftPushDownSqlStatement()
+        }} + ConstantString("END")
+
+      case Coalesce(columns) =>
+        ConstantString(expr.prettyName.toUpperCase) +
+          blockStatement(
+            mkStatement(
+              columns.map(convertStatement(_, fields)),
+              ", "
+            )
+          )
+
+      case _ => null
+    })
+  }
+
+  private final def setToExpr(set: Set[Any]): Seq[Expression] = {
+    set.map {
+      case d: Decimal => Literal(d, DecimalType(d.precision, d.scale))
+      case s @ (_: String | _: UTF8String) => Literal(s, StringType)
+      case d: Double => Literal(d, DoubleType)
+      case e: Expression => e
+      case default =>
+        // This exception will not break the connector. It will be caught in
+        // QueryBuilder.
+        throw new IllegalArgumentException(
+          s"${default.getClass.getSimpleName} @ MiscStatement.setToExpr"
+        )
+    }.toSeq
+  }
+
+  /** Attempts a best effort conversion from a SparkType
+  * to a connector type to be used in a Cast.
+  * https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
+  */
+  private[querygeneration] final def getCastType(t: DataType): Option[String] =
+    Option(t match {
+      case StringType => "VARCHAR"
+      case BinaryType => "BINARY"
+      case DateType => "DATE"
+      case TimestampType => "TIMESTAMP"
+      case d: DecimalType =>
+        "DECIMAL(" + d.precision + ", " + d.scale + ")"
+      case IntegerType | LongType => "NUMERIC"
+      case FloatType | DoubleType => "FLOAT"
+      case _ => null
+    })
+
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/NumericStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/NumericStatement.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, Asin, Atan, Attribute, Ceil, CheckOverflow, Cos, Cosh, Exp, Expression, Floor, Greatest, Least, Log, Pi, Pow, PromotePrecision, Rand, Round, Sin, Sinh, Sqrt, Tan, Tanh, UnaryMinus}
+
+import io.github.spark_redshift_community.spark.redshift._
+
+/** Extractor for boolean expressions (return true or false). */
+private[querygeneration] object NumericStatement {
+
+  /** Used mainly by QueryGeneration.convertExpression. This matches
+  * a tuple of (Expression, Seq[Attribute]) representing the expression to
+  * be matched and the fields that define the valid fields in the current expression
+  * scope, respectively.
+  *
+  * @param expAttr A pair-tuple representing the expression to be matched and the
+  *                attribute fields.
+  * @return An option containing the translated SQL, if there is a match, or None if there
+  *         is no match.
+  */
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    Option(expr match {
+      case _: Abs | _: Acos | _: Cos | _: Tan | _: Tanh | _: Cosh | _: Atan |
+          _: Floor | _: Sin | _: Log | _: Asin | _: Sqrt | _: Ceil | _: Sqrt |
+          _: Sinh | _: Greatest | _: Least | _: Exp =>
+        ConstantString(expr.prettyName.toUpperCase) +
+          blockStatement(convertStatements(fields, expr.children: _*))
+
+      // On Spark 2.4, UnaryMinus() has 1 parameter only.
+      case UnaryMinus(child) =>
+        ConstantString("-") +
+          blockStatement(convertStatement(child, fields))
+
+      case Pow(left, right) =>
+        ConstantString("POWER") +
+          blockStatement(
+            convertStatement(left, fields) + "," + convertStatement(
+              right,
+              fields
+            )
+          )
+
+      case PromotePrecision(child) => convertStatement(child, fields)
+
+      // The 3rd parameter is new from spark 3.0
+      case CheckOverflow(child, t) =>
+        MiscStatement.getCastType(t) match {
+          case Some(cast) =>
+            ConstantString("CAST") +
+              blockStatement(convertStatement(child, fields) + "AS" + cast)
+          case _ => convertStatement(child, fields)
+        }
+
+      // Spark has resolved PI() as 3.141592653589793
+      // Suppose connector can't see Pi().
+      case Pi() => ConstantString("PI()") !
+
+      // On Spark 2.4, Rand() has 1 parameter only.
+      case Rand(seed) =>
+        ConstantString("RANDOM") + blockStatement(
+          LongVariable(Option(seed).map(_.asInstanceOf[Long])) !
+        )
+      case Round(child, scale) =>
+        ConstantString("ROUND") + blockStatement(
+          convertStatements(fields, child, scale)
+        )
+
+      case _ => null
+    })
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/QueryBuilder.scala
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// scalastyle:off line.size.limit
+// https://github.com/ActionIQ-OSS/spark-snowflake/blob/spark_2.4/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryBuilder.scala
+// scalastyle:on line.size.limit
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import scala.reflect.ClassTag
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.types.{StructField, StructType}
+import io.github.spark_redshift_community.spark.redshift.{RedshiftPushDownSqlStatement, RedshiftRelation}
+import org.apache.spark.sql.catalyst.InternalRow
+
+/** This class takes a Spark LogicalPlan and attempts to generate
+ * a query for Snowflake using tryBuild(). Here we use lazy instantiation
+ * to avoid building the query from the get-go without tryBuild().
+ */
+
+private[querygeneration] class QueryBuilder(plan: LogicalPlan) extends Logging {
+
+  import QueryBuilder.convertProjections
+
+  private final val alias = Iterator.from(0).map(n => s"SUBQUERY_$n")
+
+  lazy val rdd: RDD[InternalRow] = toRDD[InternalRow]
+  lazy val tryBuild: Option[QueryBuilder] =
+    if (treeRoot == null) None else Some(this)
+
+  lazy val statement: RedshiftPushDownSqlStatement = {
+    checkTree()
+    treeRoot.getStatement()
+  }
+
+  lazy val getOutput: Seq[Attribute] = {
+    checkTree()
+    treeRoot.output
+  }
+  /** Finds the SourceQueryRedshift in this given tree. */
+  private lazy val source = {
+    checkTree()
+    treeRoot
+      .find {
+        case q: SourceQueryRedshift => q
+      }
+      .getOrElse(
+        throw new IllegalArgumentException(
+          "Something went wrong: a query tree was generated with no " +
+            "SourceQueryRedshift found."
+        )
+      )
+  }
+  private[redshift] lazy val treeRoot: RedshiftPushDownQuery = {
+    try {
+      generateQueries(plan).get
+    } catch {
+      case e: Exception =>
+        log.warn(s"Not able to generate queries: ${e.getMessage}")
+        null
+    }
+  }
+
+  private def toRDD[T: ClassTag]: RDD[InternalRow] = {
+
+    val schema = StructType(
+      getOutput
+        .map(attr => StructField(attr.name, attr.dataType, attr.nullable))
+    )
+
+    source.relation.buildRDDFromSQL(statement, schema)
+  }
+
+  private def checkTree(): Unit = {
+    if (treeRoot == null) {
+      throw new IllegalArgumentException(
+        "QueryBuilder's tree accessed without generation."
+      )
+    }
+  }
+
+  private def generateQueries(plan: LogicalPlan): Option[RedshiftPushDownQuery] = {
+    plan match {
+      case l@LogicalRelation(redshiftRelation: RedshiftRelation, _, _, _) =>
+        Some(SourceQueryRedshift(redshiftRelation, l.output, alias.next))
+
+      case UnaryOp(child) =>
+        generateQueries(child) map { subQuery =>
+          plan match {
+            case Filter(condition, _) =>
+              FilterQueryRedshift(Seq(condition), subQuery, alias.next)
+            case Project(fields, _) =>
+              ProjectQueryRedshift(fields, subQuery, alias.next)
+            case Aggregate(groups, fields, _) =>
+              AggregateQueryRedshift(fields, groups, subQuery, alias.next)
+            case Limit(limitExpr, Sort(orderExpr, true, _)) =>
+              SortLimitQueryRedshift(Some(limitExpr), orderExpr, subQuery, alias.next)
+            case Limit(limitExpr, _) =>
+              SortLimitQueryRedshift(Some(limitExpr), Seq.empty, subQuery, alias.next)
+
+            case Sort(orderExpr, true, Limit(limitExpr, _)) =>
+              SortLimitQueryRedshift(Some(limitExpr), orderExpr, subQuery, alias.next)
+            case Sort(orderExpr, true, _) =>
+              SortLimitQueryRedshift(None, orderExpr, subQuery, alias.next)
+
+            case Window(windowExpressions, _, _, _) =>
+              WindowQueryRedshift(
+                windowExpressions,
+                subQuery,
+                alias.next,
+                if (plan.output.isEmpty) None else Some(plan.output)
+              )
+
+            case _ => subQuery
+          }
+        }
+
+      case BinaryOp(left, right) =>
+        generateQueries(left).flatMap { l =>
+          generateQueries(right) map { r =>
+            plan match {
+              // The 5th parameter is new from spark 3.0
+              case Join(_, _, joinType, condition) =>
+                joinType match {
+                  case Inner | LeftOuter | RightOuter | FullOuter =>
+                    JoinQueryRedshift(l, r, condition, joinType, alias.next)
+                  case LeftSemi =>
+                    LeftSemiJoinQueryRedshift(l, r, condition, isAntiJoin = false, alias)
+                  case LeftAnti =>
+                    LeftSemiJoinQueryRedshift(l, r, condition, isAntiJoin = true, alias)
+                  case _ => throw new IllegalArgumentException("can't resolve this join")
+                }
+            }
+          }
+        }
+
+      // On Spark 2.4, Union() has 1 parameter only.
+      case Union(children) =>
+        Some(UnionQueryRedshift(children, alias.next))
+
+      case Expand(projections, output, child) =>
+        val children = projections.map { p =>
+          val proj = convertProjections(p, output)
+          Project(proj, child)
+        }
+        Some(UnionQueryRedshift(children, alias.next, Some(output)))
+
+      case _ =>
+        // This exception is not a real issue. It will be caught in
+        // QueryBuilder.
+        None
+    }
+  }
+
+}
+
+private[redshift] object QueryBuilder {
+
+  final def convertProjections(projections: Seq[Expression],
+                               output: Seq[Attribute]): Seq[NamedExpression] = {
+    projections zip output map { expr =>
+      expr._1 match {
+        case e: NamedExpression => e
+        case _ => Alias(expr._1, expr._2.name)(expr._2.exprId)
+      }
+    }
+  }
+
+  def getRDDFromPlan(
+                      plan: LogicalPlan
+                    ): Option[(Seq[Attribute], RDD[InternalRow])] = {
+    val qb = new QueryBuilder(plan)
+
+    qb.tryBuild.map { executedBuilder =>
+      (executedBuilder.getOutput, executedBuilder.rdd)
+    }
+  }
+
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/QueryBuilder.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/QueryBuilder.scala
@@ -175,8 +175,10 @@ private[querygeneration] class QueryBuilder(plan: LogicalPlan) extends Logging {
 
 private[redshift] object QueryBuilder {
 
-  final def convertProjections(projections: Seq[Expression],
-                               output: Seq[Attribute]): Seq[NamedExpression] = {
+  final def convertProjections(
+    projections: Seq[Expression],
+    output: Seq[Attribute]
+  ): Seq[NamedExpression] = {
     projections zip output map { expr =>
       expr._1 match {
         case e: NamedExpression => e
@@ -186,8 +188,8 @@ private[redshift] object QueryBuilder {
   }
 
   def getRDDFromPlan(
-                      plan: LogicalPlan
-                    ): Option[(Seq[Attribute], RDD[InternalRow])] = {
+    plan: LogicalPlan
+  ): Option[(Seq[Attribute], RDD[InternalRow])] = {
     val qb = new QueryBuilder(plan)
 
     qb.tryBuild.map { executedBuilder =>

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/QueryHelper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/QueryHelper.scala
@@ -25,15 +25,14 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import io.github.spark_redshift_community.spark.redshift.RedshiftPushDownSqlStatement
 
 private[querygeneration] case class QueryHelper(
-                                                 children: Seq[RedshiftPushDownQuery],
-                                                 projections: Option[Seq[NamedExpression]] = None,
-                                                 outputAttributes: Option[Seq[Attribute]],
-                                                 alias: String,
-                                                 conjunctionStatement: RedshiftPushDownSqlStatement = new RedshiftPushDownSqlStatement(),
-                                                 fields: Option[Seq[Attribute]] = None,
-                                                 visibleAttributeOverride: Option[Seq[Attribute]] = None
-                                               ) {
-
+  children: Seq[RedshiftPushDownQuery],
+  projections: Option[Seq[NamedExpression]] = None,
+  outputAttributes: Option[Seq[Attribute]],
+  alias: String,
+  conjunctionStatement: RedshiftPushDownSqlStatement = new RedshiftPushDownSqlStatement(),
+  fields: Option[Seq[Attribute]] = None,
+  visibleAttributeOverride: Option[Seq[Attribute]] = None
+) {
   val colSet: Seq[Attribute] =
     if (fields.isEmpty) {
       children.foldLeft(Seq.empty[Attribute])(

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/QueryHelper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/QueryHelper.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off line.size.limit
+// https://github.com/ActionIQ-OSS/spark-snowflake/blob/spark_2.4/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/QueryHelper.scala
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, NamedExpression}
+
+import io.github.spark_redshift_community.spark.redshift.RedshiftPushDownSqlStatement
+
+private[querygeneration] case class QueryHelper(
+                                                 children: Seq[RedshiftPushDownQuery],
+                                                 projections: Option[Seq[NamedExpression]] = None,
+                                                 outputAttributes: Option[Seq[Attribute]],
+                                                 alias: String,
+                                                 conjunctionStatement: RedshiftPushDownSqlStatement = new RedshiftPushDownSqlStatement(),
+                                                 fields: Option[Seq[Attribute]] = None,
+                                                 visibleAttributeOverride: Option[Seq[Attribute]] = None
+                                               ) {
+
+  val colSet: Seq[Attribute] =
+    if (fields.isEmpty) {
+      children.foldLeft(Seq.empty[Attribute])(
+        (x, y) => {
+          val attrs =
+            if (y.helper.visibleAttributeOverride.isEmpty) {
+              y.helper.outputWithQualifier
+            } else {
+              y.helper.visibleAttributeOverride.get
+            }
+
+          x ++ attrs
+        }
+      )
+    } else {
+      fields.get
+    }
+
+  val pureColSet: Seq[Attribute] =
+    children.foldLeft(Seq.empty[Attribute])((x, y) => x ++ y.helper.output)
+
+  val processedProjections: Option[Seq[NamedExpression]] = projections
+    .map(
+      p =>
+        p.map(
+          e =>
+            colSet.find(c => c.exprId == e.exprId) match {
+              case Some(a) if e.isInstanceOf[AttributeReference] =>
+                AttributeReference(a.name, a.dataType, a.nullable, a.metadata)(
+                  a.exprId
+                )
+              case _ => e
+            }
+        )
+    )
+    .map(p => renameColumns(p, alias))
+
+  val columns: Option[RedshiftPushDownSqlStatement] =
+    processedProjections.map(
+      p => mkStatement(p.map(convertStatement(_, colSet)), ",")
+    )
+
+  lazy val output: Seq[Attribute] = {
+    outputAttributes.getOrElse(
+      processedProjections.map(p => p.map(_.toAttribute)).getOrElse {
+        if (children.isEmpty) {
+          throw new IllegalArgumentException(
+            "Query output attributes must not be empty when it has no children."
+          )
+        } else {
+          children
+            .foldLeft(Seq.empty[Attribute])((x, y) => x ++ y.helper.output)
+        }
+      }
+    )
+  }
+
+  var outputWithQualifier: Seq[AttributeReference] = output.map(
+    a =>
+      AttributeReference(a.name, a.dataType, a.nullable, a.metadata)(
+        a.exprId,
+        Seq[String](alias)
+      )
+  )
+
+  // For OUTER JOIN, the column's nullability may need to be modified as true
+  def nullableOutputWithQualifier: Seq[AttributeReference] = output.map(
+    a =>
+      AttributeReference(a.name, a.dataType, nullable = true, a.metadata)(
+        a.exprId,
+        Seq[String](alias)
+      )
+  )
+
+  val sourceStatement: RedshiftPushDownSqlStatement = {
+    if (children.nonEmpty) {
+      mkStatement(children.map(_.getStatement(true)), conjunctionStatement)
+    } else {
+      conjunctionStatement
+    }
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/RedshiftPushDownQuery.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/RedshiftPushDownQuery.scala
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off line.size.limit
+// https://github.com/ActionIQ-OSS/spark-snowflake/blob/spark_2.4/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/SnowflakeQuery.scala
+// scalastyle:on line.size.limit
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Cast, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+import io.github.spark_redshift_community.spark.redshift._
+
+abstract sealed class RedshiftPushDownQuery {
+
+  /** Output columns. */
+  lazy val output: Seq[Attribute] =
+    if (helper == null) Seq.empty
+    else {
+      helper.output
+        .map { col =>
+          val orig_name = col.name
+
+          Alias(Cast(col, col.dataType), orig_name)(
+            col.exprId,
+            Seq.empty[String],
+            Some(col.metadata)
+          )
+        }
+        .map(_.toAttribute)
+    }
+
+  val helper: QueryHelper
+
+  /** What comes after the FROM clause. */
+  val suffixStatement: RedshiftPushDownSqlStatement = new RedshiftPushDownSqlStatement()
+
+  def expressionToStatement(expr: Expression): RedshiftPushDownSqlStatement =
+    convertStatement(expr, helper.colSet)
+
+  /** Converts this query into a String representing the SQL.
+   *
+   * @param useAlias Whether or not to alias this translated block of SQL.
+   * @return SQL statement for this query.
+   */
+  def getStatement(useAlias: Boolean = false): RedshiftPushDownSqlStatement = {
+    val stmt =
+      ConstantString("SELECT") + helper.columns.getOrElse(ConstantString("*") !) + "FROM" +
+        helper.sourceStatement + suffixStatement
+
+    if (useAlias) {
+      blockStatement(stmt, helper.alias)
+    } else {
+      stmt
+    }
+  }
+
+  /** Finds a particular query type in the overall tree.
+   *
+   * @param query PartialFunction defining a positive result.
+   * @tparam T RedshiftPushDownQuery type
+   * @return Option[T] for one positive match, or None if nothing found.
+   */
+  def find[T](query: PartialFunction[RedshiftPushDownQuery, T]): Option[T] =
+    query
+      .lift(this)
+      .orElse(
+        if (helper.children.isEmpty) None
+        else helper.children.head.find(query)
+      )
+
+  /** Determines if two subtrees can be joined together.
+   * Should determine if two sources are in same db?
+   * set to true temporarily
+   *
+   * @param otherTree The other tree, can it be joined with this one?
+   * @return True if can be joined, or False if not.
+   */
+  def canJoin(otherTree: RedshiftPushDownQuery): Boolean = {
+    true
+  }
+}
+
+/** The query for a base type (representing a table or view).
+ *
+ * @constructor
+ * @param relation   The base PushDownRelation representing the basic table, view,
+ *                   or subquery defined by the user.
+ * @param refColumns Columns used to override the output generation for the QueryHelper.
+ *                   These are the columns resolved by PushDownRelation.
+ * @param alias      Query alias.
+ */
+case class SourceQueryRedshift(relation: RedshiftRelation,
+                               refColumns: Seq[Attribute],
+                               alias: String)
+  extends RedshiftPushDownQuery {
+
+  override val helper: QueryHelper = QueryHelper(
+    children = Seq.empty,
+    projections = None,
+    outputAttributes = Some(refColumns),
+    alias = alias,
+    conjunctionStatement = blockStatementForSourceQuery(
+      ConstantString(relation.jdbcOptions.tableOrQuery) + "",
+      "redshift_query_alias"
+    )
+  )
+
+  override def find[T](query: PartialFunction[RedshiftPushDownQuery, T]): Option[T] =
+    query.lift(this)
+}
+
+/** The query for a filter operation.
+ *
+ * @constructor
+ * @param conditions The filter condition.
+ * @param child      The child node.
+ * @param alias      Query alias.
+ */
+case class FilterQueryRedshift(conditions: Seq[Expression],
+                               child: RedshiftPushDownQuery,
+                               alias: String,
+                               fields: Option[Seq[Attribute]] = None)
+  extends RedshiftPushDownQuery {
+
+  override val helper: QueryHelper =
+    QueryHelper(
+      children = Seq(child),
+      projections = None,
+      outputAttributes = None,
+      alias = alias,
+      fields = fields
+    )
+
+  override val suffixStatement: RedshiftPushDownSqlStatement =
+    ConstantString("WHERE") + mkStatement(
+      conditions.map(expressionToStatement),
+      "AND"
+    )
+}
+
+/** The query for a projection operation.
+ *
+ * @constructor
+ * @param columns The projection columns.
+ * @param child   The child node.
+ * @param alias   Query alias.
+ */
+case class ProjectQueryRedshift(columns: Seq[NamedExpression],
+                                child: RedshiftPushDownQuery,
+                                alias: String)
+  extends RedshiftPushDownQuery {
+
+  override val helper: QueryHelper =
+    QueryHelper(
+      children = Seq(child),
+      projections = Some(columns),
+      outputAttributes = None,
+      alias = alias
+    )
+}
+
+/** The query for a aggregation operation.
+ *
+ * @constructor
+ * @param columns The projection columns, containing also the aggregate expressions.
+ * @param groups  The grouping columns.
+ * @param child   The child node.
+ * @param alias   Query alias.
+ */
+case class AggregateQueryRedshift(columns: Seq[NamedExpression],
+                                  groups: Seq[Expression],
+                                  child: RedshiftPushDownQuery,
+                                  alias: String)
+  extends RedshiftPushDownQuery {
+
+  override val helper: QueryHelper =
+    QueryHelper(
+      children = Seq(child),
+      projections = if (columns.isEmpty) None else Some(columns),
+      outputAttributes = None,
+      alias = alias
+    )
+
+  override val suffixStatement: RedshiftPushDownSqlStatement =
+    if (groups.nonEmpty) {
+      ConstantString("GROUP BY") +
+        mkStatement(groups.map(expressionToStatement), ",")
+    } else {
+      // SNOW-201486: Insert a limit 1 to ensure that only one row returns if there
+      // are no grouping expressions
+      ConstantString("LIMIT 1").toStatement
+    }
+}
+
+/** The query for Sort and Limit operations.
+ *
+ * @constructor
+ * @param limit   Limit expression.
+ * @param orderBy Order By expressions.
+ * @param child   The child node.
+ * @param alias   Query alias.
+ */
+case class SortLimitQueryRedshift(limit: Option[Expression],
+                                  orderBy: Seq[Expression],
+                                  child: RedshiftPushDownQuery,
+                                  alias: String)
+  extends RedshiftPushDownQuery {
+
+  override val helper: QueryHelper =
+    QueryHelper(
+      children = Seq(child),
+      projections = None,
+      outputAttributes = None,
+      alias = alias
+    )
+
+  override val suffixStatement: RedshiftPushDownSqlStatement = {
+    val statementFirstPart =
+      if (orderBy.nonEmpty) {
+        ConstantString("ORDER BY") + mkStatement(
+          orderBy.map(expressionToStatement),
+          ","
+        )
+      } else {
+        new RedshiftPushDownSqlStatement()
+      }
+
+    // TODO need to change limit to top for azure
+
+    statementFirstPart + limit
+      .map(ConstantString("LIMIT") + expressionToStatement(_))
+      .getOrElse(new RedshiftPushDownSqlStatement())
+    statementFirstPart
+  }
+}
+
+/** The query for join operations.
+ *
+ * @constructor
+ * @param left       The left query subtree.
+ * @param right      The right query subtree.
+ * @param conditions The join conditions.
+ * @param joinType   The join type.
+ * @param alias      Query alias.
+ */
+case class JoinQueryRedshift(left: RedshiftPushDownQuery,
+                             right: RedshiftPushDownQuery,
+                             conditions: Option[Expression],
+                             joinType: JoinType,
+                             alias: String)
+  extends RedshiftPushDownQuery {
+
+  val conj: String = joinType match {
+    case Inner =>
+      // keep the nullability for both projections
+      "INNER JOIN"
+    case LeftOuter =>
+      // Update the column's nullability of right table as true
+      right.helper.outputWithQualifier =
+        right.helper.nullableOutputWithQualifier
+      "LEFT OUTER JOIN"
+    case RightOuter =>
+      // Update the column's nullability of left table as true
+      left.helper.outputWithQualifier =
+        left.helper.nullableOutputWithQualifier
+      "RIGHT OUTER JOIN"
+    case FullOuter =>
+      // Update the column's nullability of both tables as true
+      left.helper.outputWithQualifier =
+        left.helper.nullableOutputWithQualifier
+      right.helper.outputWithQualifier =
+        right.helper.nullableOutputWithQualifier
+      "FULL OUTER JOIN"
+    case _ => throw new IllegalArgumentException("cant resolve this join")
+  }
+
+  override val helper: QueryHelper =
+    QueryHelper(
+      children = Seq(left, right),
+      projections = Some(
+        left.helper.outputWithQualifier ++ right.helper.outputWithQualifier
+      ),
+      outputAttributes = None,
+      alias = alias,
+      conjunctionStatement = ConstantString(conj) !
+    )
+
+  override val suffixStatement: RedshiftPushDownSqlStatement =
+    conditions
+      .map(ConstantString("ON") + expressionToStatement(_))
+      .getOrElse(new RedshiftPushDownSqlStatement())
+
+  override def find[T](query: PartialFunction[RedshiftPushDownQuery, T]): Option[T] =
+    query.lift(this).orElse(left.find(query)).orElse(right.find(query))
+}
+
+case class LeftSemiJoinQueryRedshift(left: RedshiftPushDownQuery,
+                                     right: RedshiftPushDownQuery,
+                                     conditions: Option[Expression],
+                                     isAntiJoin: Boolean = false,
+                                     alias: Iterator[String])
+  extends RedshiftPushDownQuery {
+
+  override val helper: QueryHelper =
+    QueryHelper(
+      children = Seq(left),
+      projections = Some(left.helper.outputWithQualifier),
+      outputAttributes = None,
+      alias = alias.next
+    )
+
+  val cond: Seq[Expression] =
+    if (conditions.isEmpty) Seq.empty else Seq(conditions.get)
+
+  val anti: String = if (isAntiJoin) " NOT " else " "
+
+  override val suffixStatement: RedshiftPushDownSqlStatement =
+    ConstantString("WHERE") + anti + "EXISTS" + blockStatement(
+      FilterQueryRedshift(
+        conditions = cond,
+        child = right,
+        alias = alias.next,
+        fields = Some(
+          left.helper.outputWithQualifier ++ right.helper.outputWithQualifier
+        )
+      ).getStatement()
+    )
+
+  override def find[T](query: PartialFunction[RedshiftPushDownQuery, T]): Option[T] =
+    query.lift(this).orElse(left.find(query)).orElse(right.find(query))
+}
+
+/** The query for union.
+ *
+ * @constructor
+ * @param children Children of the union expression.
+ */
+case class UnionQueryRedshift(children: Seq[LogicalPlan],
+                              alias: String,
+                              outputCols: Option[Seq[Attribute]] = None)
+  extends RedshiftPushDownQuery {
+
+  val queries: Seq[RedshiftPushDownQuery] = children.map { child =>
+    new QueryBuilder(child).treeRoot
+  }
+
+  override val helper: QueryHelper =
+    QueryHelper(
+      children = queries,
+      outputAttributes = Some(queries.head.helper.output),
+      alias = alias,
+      visibleAttributeOverride =
+        Some(queries.foldLeft(Seq.empty[Attribute])((x, y) => x ++ y.helper.output).map(
+          a =>
+            AttributeReference(a.name, a.dataType, a.nullable, a.metadata)(
+              a.exprId,
+              Seq[String](alias)
+            )))
+    )
+
+  override def getStatement(useAlias: Boolean): RedshiftPushDownSqlStatement = {
+    val query =
+      if (queries.nonEmpty) {
+        mkStatement(
+          queries.map(c => blockStatement(c.getStatement())),
+          "UNION ALL"
+        )
+      } else {
+        new RedshiftPushDownSqlStatement()
+      }
+
+    if (useAlias) {
+      blockStatement(query, alias)
+    } else {
+      query
+    }
+  }
+
+  override def find[T](query: PartialFunction[RedshiftPushDownQuery, T]): Option[T] =
+    query
+      .lift(this)
+      .orElse(
+        queries
+          .map(q => q.find(query))
+          .view
+          .foldLeft[Option[T]](None)(_ orElse _)
+      )
+}
+
+/** Query including a windowing clause.
+ *
+ * @constructor
+ * @param windowExpressions The windowing expressions.
+ * @param child             The child query.
+ * @param alias             Query alias.
+ * @param fields            The fields generated by this query referenceable by the parent.
+ */
+case class WindowQueryRedshift(windowExpressions: Seq[NamedExpression],
+                               child: RedshiftPushDownQuery,
+                               alias: String,
+                               fields: Option[Seq[Attribute]])
+  extends RedshiftPushDownQuery {
+
+  val projectionVector: Seq[NamedExpression] =
+    windowExpressions ++ child.helper.outputWithQualifier
+
+  // We need to reorder the projections based on the output vector
+  val orderedProjections: Option[Seq[NamedExpression]] =
+    fields.map(_.map(reference => {
+      val origPos = projectionVector.map(_.exprId).indexOf(reference.exprId)
+      projectionVector(origPos)
+    }))
+
+  override val helper: QueryHelper =
+    QueryHelper(
+      children = Seq(child),
+      projections = orderedProjections,
+      outputAttributes = None,
+      alias = alias
+    )
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/StringStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/StringStatement.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{Ascii, Attribute, Concat, Expression, Length, Like, Lower, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Upper}
+
+import io.github.spark_redshift_community.spark.redshift._
+
+/** Extractor for boolean expressions (return true or false). */
+private[querygeneration] object StringStatement {
+
+  /** Used mainly by QueryGeneration.convertExpression. This matches
+  * a tuple of (Expression, Seq[Attribute]) representing the expression to
+  * be matched and the fields that define the valid fields in the current expression
+  * scope, respectively.
+  *
+  * @param expAttr A pair-tuple representing the expression to be matched and the
+  *                attribute fields.
+  * @return An option containing the translated SQL, if there is a match, or None if there
+  *         is no match.
+  */
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    Option(expr match {
+      case _: Ascii | _: Lower | _: Substring | _: StringLPad | _: StringRPad |
+          _: StringTranslate | _: StringTrim | _: StringTrimLeft |
+          _: StringTrimRight | _: Substring | _: Upper | _: Length =>
+        ConstantString(expr.prettyName.toUpperCase) +
+          blockStatement(convertStatements(fields, expr.children: _*))
+
+      case Concat(children) =>
+        val rightSide =
+          if (children.length > 2) Concat(children.drop(1)) else children(1)
+        ConstantString("CONCAT") + blockStatement(
+          convertStatement(children.head, fields) + "," +
+            convertStatement(rightSide, fields)
+        )
+
+      // ESCAPE Char is supported from Spark 3.0
+      case Like(left, right) =>
+        convertStatement(left, fields) + "LIKE" + convertStatement(
+          right,
+          fields
+        )
+
+      case _ => null
+    })
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/UnaryOp.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/UnaryOp.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.plans.logical._
+
+/** Extractor for supported unary operations. */
+private[querygeneration] object UnaryOp {
+
+  def unapply(node: UnaryNode): Option[LogicalPlan] =
+    node match {
+      case _: Filter | _: Project | _: GlobalLimit | _: LocalLimit |
+          _: Aggregate | _: Sort | _: ReturnAnswer | _: Window =>
+        Some(node.child)
+
+      case _ => None
+    }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/UnsupportedStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/UnsupportedStatement.scala
@@ -34,8 +34,8 @@ private[querygeneration] object UnsupportedStatement {
   *         is no match.
   */
   def unapply(
-               expAttr: (Expression, Seq[Attribute])
-             ): Option[RedshiftPushDownSqlStatement] = {
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
     val expr = expAttr._1
 
     // This exception is not a real issue. It will be caught in

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/UnsupportedStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/UnsupportedStatement.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, PythonUDF, ScalaUDF}
+import org.apache.spark.sql.execution.aggregate.ScalaUDAF
+
+import io.github.spark_redshift_community.spark.redshift.RedshiftPushDownSqlStatement
+
+private[querygeneration] object UnsupportedStatement {
+  /** Used mainly by QueryGeneration.convertStatement. This matches
+  * a tuple of (Expression, Seq[Attribute]) representing the expression to
+  * be matched and the fields that define the valid fields in the current expression
+  * scope, respectively.
+  *
+  * @param expAttr A pair-tuple representing the expression to be matched and the
+  *                attribute fields.
+  * @return An option containing the translated SQL, if there is a match, or None if there
+  *         is no match.
+  */
+  def unapply(
+               expAttr: (Expression, Seq[Attribute])
+             ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+
+    // This exception is not a real issue. It will be caught in
+    // QueryBuilder. It can't be done here
+    // because it is not clear whether there are any cloud tables here.
+    throw new IllegalArgumentException(
+      "failed to pushdown")
+  }
+
+  // Determine whether the unsupported operation is known or not.
+  private def isKnownUnsupportedOperation(expr: Expression): Boolean = {
+    // The pushdown for UDF is known unsupported
+    (expr.isInstanceOf[PythonUDF]
+      || expr.isInstanceOf[ScalaUDF]
+      || expr.isInstanceOf[ScalaUDAF])
+  }
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/WindowStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/WindowStatement.scala
@@ -86,10 +86,10 @@ private[querygeneration] object WindowStatement {
 
   // Handle window block.
   private final def windowBlock(
-                                 spec: WindowSpecDefinition,
-                                 fields: Seq[Attribute],
-                                 useWindowFrame: Boolean
-                               ): RedshiftPushDownSqlStatement = {
+    spec: WindowSpecDefinition,
+    fields: Seq[Attribute],
+    useWindowFrame: Boolean
+  ): RedshiftPushDownSqlStatement = {
     val partitionBy =
       if (spec.partitionSpec.isEmpty) {
         new RedshiftPushDownSqlStatement()

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/WindowStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/WindowStatement.scala
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, DenseRank, Expression, PercentRank, Rank, RowNumber, WindowExpression, WindowSpecDefinition}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+
+import io.github.spark_redshift_community.spark.redshift._
+
+private[querygeneration] object WindowStatement {
+
+  /** Used mainly by QueryGeneration.convertExpression. This matches
+  * a tuple of (Expression, Seq[Attribute]) representing the expression to
+  * be matched and the fields that define the valid fields in the current expression
+  * scope, respectively.
+  *
+  * @param expAttr A pair-tuple representing the expression to be matched and the
+  *                attribute fields.
+  * @return An option containing the translated SQL, if there is a match, or None if there
+  *         is no match.
+  */
+  def unapply(
+    expAttr: (Expression, Seq[Attribute])
+  ): Option[RedshiftPushDownSqlStatement] = {
+    val expr = expAttr._1
+    val fields = expAttr._2
+
+    Option(expr match {
+      // Handle Window Expression.
+      case WindowExpression(func, spec) =>
+        func match {
+          // These functions in Snowflake support a window frame.
+          // Need to be tested in different connector
+          // Note that pushdown for these may or may not yet be supported in the connector.
+          case _: Rank | _: DenseRank | _: PercentRank =>
+            convertStatement(func, fields) + " OVER " + windowBlock(
+              spec,
+              fields,
+              useWindowFrame = true
+            )
+
+          // Disable window function pushdown if
+          // 1. The function are both window function and aggregate function
+          // 2. User specifies Window Frame. But there is no way to detect
+          //    whether the window function has Window Frame or not.
+          //    So we check whether ORDER BY is specified instead.
+          //    This may disable the window function which has ORDER BY but
+          //    without Window Frame. This is not an issue because it still works.
+          case _: AggregateExpression if spec.orderSpec.nonEmpty =>
+            null
+
+          // These do not.
+          case _ =>
+            convertStatement(func, fields) + " OVER " + windowBlock(
+              spec,
+              fields,
+              useWindowFrame = false
+            )
+        }
+
+      // Handle supported window function
+      case _: RowNumber | _: Rank | _: DenseRank =>
+        ConstantString(expr.prettyName.toUpperCase) + "()"
+
+      // ToDO Add PercentRank support
+      case _: PercentRank => null
+
+      case _ => null
+    })
+  }
+
+  // Handle window block.
+  private final def windowBlock(
+                                 spec: WindowSpecDefinition,
+                                 fields: Seq[Attribute],
+                                 useWindowFrame: Boolean
+                               ): RedshiftPushDownSqlStatement = {
+    val partitionBy =
+      if (spec.partitionSpec.isEmpty) {
+        new RedshiftPushDownSqlStatement()
+      } else {
+        ConstantString("PARTITION BY") +
+          mkStatement(spec.partitionSpec.map(convertStatement(_, fields)), ",")
+      }
+
+    val orderBy =
+      if (spec.orderSpec.isEmpty) {
+        new RedshiftPushDownSqlStatement()
+      } else {
+        ConstantString("ORDER BY") +
+          mkStatement(spec.orderSpec.map(convertStatement(_, fields)), ",")
+      }
+
+    val fromTo =
+      if (!useWindowFrame || spec.orderSpec.isEmpty) ""
+      else " " + spec.frameSpecification.sql
+
+    blockStatement(partitionBy + orderBy + fromTo)
+  }
+
+}

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/package.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/package.scala
@@ -31,20 +31,20 @@ import io.github.spark_redshift_community.spark.redshift._
 
 package object querygeneration {
   private[querygeneration] final def blockStatement(
-                                                     stmt: RedshiftPushDownSqlStatement
-                                                   ): RedshiftPushDownSqlStatement =
+    stmt: RedshiftPushDownSqlStatement
+  ): RedshiftPushDownSqlStatement =
     ConstantString("(") + stmt + ")"
 
   private[querygeneration] final def blockStatement(
-                                                     stmt: RedshiftPushDownSqlStatement,
-                                                     alias: String
-                                                   ): RedshiftPushDownSqlStatement =
+    stmt: RedshiftPushDownSqlStatement,
+    alias: String
+  ): RedshiftPushDownSqlStatement =
     blockStatement(stmt) + "AS" + wrapStatement(alias)
 
   private[querygeneration] final def blockStatementForSourceQuery(
-  stmt: RedshiftPushDownSqlStatement,
-                                                                   alias: String
-                                                                 ): RedshiftPushDownSqlStatement =
+    stmt: RedshiftPushDownSqlStatement,
+    alias: String
+  ): RedshiftPushDownSqlStatement =
     stmt + "AS" + wrapStatement(alias)
 
   /** This adds an attribute as part of a SQL expression, searching in the provided
@@ -56,9 +56,9 @@ package object querygeneration {
    * @return A RedshiftPushDownSqlStatement representing the attribute expression.
    */
   private[querygeneration] final def addAttributeStatement(
-                                                            attr: Attribute,
-                                                            fields: Seq[Attribute]
-                                                          ): RedshiftPushDownSqlStatement = {
+    attr: Attribute,
+    fields: Seq[Attribute]
+  ): RedshiftPushDownSqlStatement = {
     fields.find(e => e.exprId == attr.exprId) match {
       case Some(resolved) =>
         qualifiedAttributeStatement(resolved.qualifier, resolved.name)
@@ -68,9 +68,9 @@ package object querygeneration {
 
   /** Qualifies identifiers with that of the subquery to which it belongs */
   private[querygeneration] final def qualifiedAttribute(
-                                                         alias: Seq[String],
-                                                         name: String
-                                                       ): String = {
+    alias: Seq[String],
+    name: String
+  ): String = {
     val str =
       if (alias.isEmpty) ""
       else alias.map(wrap).mkString(".") + "."
@@ -79,20 +79,20 @@ package object querygeneration {
   }
 
   private[querygeneration] final def qualifiedAttributeStatement(
-                                                                  alias: Seq[String],
-                                                                  name: String
-                                                                ): RedshiftPushDownSqlStatement =
+    alias: Seq[String],
+    name: String
+  ): RedshiftPushDownSqlStatement =
     ConstantString(qualifiedAttribute(alias, name)) !
 
   private[querygeneration] final def wrapStatement(
-                                                    name: String
-                                                  ): RedshiftPushDownSqlStatement =
+    name: String
+  ): RedshiftPushDownSqlStatement =
     ConstantString(name.toUpperCase) !
 
   private[querygeneration] def renameColumns(
-                                              origOutput: Seq[NamedExpression],
-                                              alias: String
-                                            ): Seq[NamedExpression] = {
+    origOutput: Seq[NamedExpression],
+    alias: String
+  ): Seq[NamedExpression] = {
 
     val col_names = Iterator.from(0).map(n => s"COL_$n")
 
@@ -115,9 +115,9 @@ package object querygeneration {
   }
 
   private[querygeneration] final def convertStatement(
-                                                       expression: Expression,
-                                                       fields: Seq[Attribute]
-                                                     ): RedshiftPushDownSqlStatement = {
+    expression: Expression,
+    fields: Seq[Attribute]
+  ): RedshiftPushDownSqlStatement = {
     (expression, fields) match {
       case AggregationStatement(stmt) => stmt
       case BasicStatement(stmt) => stmt
@@ -133,21 +133,23 @@ package object querygeneration {
   }
 
   private[querygeneration] final def convertStatements(
-                                                        fields: Seq[Attribute],
-                                                        expressions: Expression*
-                                                      ): RedshiftPushDownSqlStatement =
+    fields: Seq[Attribute],
+    expressions: Expression*
+  ): RedshiftPushDownSqlStatement =
     mkStatement(expressions.map(convertStatement(_, fields)), ",")
 
   final def mkStatement(
-                         seq: Seq[RedshiftPushDownSqlStatement],
-                         delimiter: RedshiftPushDownSqlStatement
-                       ): RedshiftPushDownSqlStatement =
+    seq: Seq[RedshiftPushDownSqlStatement],
+    delimiter: RedshiftPushDownSqlStatement
+  ): RedshiftPushDownSqlStatement =
     seq.foldLeft(new RedshiftPushDownSqlStatement()) {
       case (left, stmt) =>
         if (left.isEmpty) stmt else left + delimiter + stmt
     }
 
-  final def mkStatement(seq: Seq[RedshiftPushDownSqlStatement],
-                        delimiter: String): RedshiftPushDownSqlStatement =
+  final def mkStatement(
+    seq: Seq[RedshiftPushDownSqlStatement],
+    delimiter: String
+  ): RedshiftPushDownSqlStatement =
     mkStatement(seq, ConstantString(delimiter) !)
 }

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/package.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/package.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off line.size.limit
+// https://github.com/ActionIQ-OSS/spark-snowflake/blob/spark_2.4/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/package.scala
+// scalastyle:on line.size.limit
+package io.github.spark_redshift_community.spark.redshift.pushdowns
+
+import org.apache.spark.sql.catalyst.expressions.{
+  Alias,
+  Attribute,
+  Expression,
+  NamedExpression
+}
+
+import io.github.spark_redshift_community.spark.redshift._
+
+package object querygeneration {
+  private[querygeneration] final def blockStatement(
+                                                     stmt: RedshiftPushDownSqlStatement
+                                                   ): RedshiftPushDownSqlStatement =
+    ConstantString("(") + stmt + ")"
+
+  private[querygeneration] final def blockStatement(
+                                                     stmt: RedshiftPushDownSqlStatement,
+                                                     alias: String
+                                                   ): RedshiftPushDownSqlStatement =
+    blockStatement(stmt) + "AS" + wrapStatement(alias)
+
+  private[querygeneration] final def blockStatementForSourceQuery(
+  stmt: RedshiftPushDownSqlStatement,
+                                                                   alias: String
+                                                                 ): RedshiftPushDownSqlStatement =
+    stmt + "AS" + wrapStatement(alias)
+
+  /** This adds an attribute as part of a SQL expression, searching in the provided
+   * fields for a match, so the subquery qualifiers are correct.
+   *
+   * @param attr   The Spark Attribute object to be added.
+   * @param fields The Seq[Attribute] containing the valid fields to be used in the expression,
+   *               usually derived from the output of a subquery.
+   * @return A RedshiftPushDownSqlStatement representing the attribute expression.
+   */
+  private[querygeneration] final def addAttributeStatement(
+                                                            attr: Attribute,
+                                                            fields: Seq[Attribute]
+                                                          ): RedshiftPushDownSqlStatement = {
+    fields.find(e => e.exprId == attr.exprId) match {
+      case Some(resolved) =>
+        qualifiedAttributeStatement(resolved.qualifier, resolved.name)
+      case None => qualifiedAttributeStatement(attr.qualifier, attr.name)
+    }
+  }
+
+  /** Qualifies identifiers with that of the subquery to which it belongs */
+  private[querygeneration] final def qualifiedAttribute(
+                                                         alias: Seq[String],
+                                                         name: String
+                                                       ): String = {
+    val str =
+      if (alias.isEmpty) ""
+      else alias.map(wrap).mkString(".") + "."
+
+    str + name
+  }
+
+  private[querygeneration] final def qualifiedAttributeStatement(
+                                                                  alias: Seq[String],
+                                                                  name: String
+                                                                ): RedshiftPushDownSqlStatement =
+    ConstantString(qualifiedAttribute(alias, name)) !
+
+  private[querygeneration] final def wrapStatement(
+                                                    name: String
+                                                  ): RedshiftPushDownSqlStatement =
+    ConstantString(name.toUpperCase) !
+
+  private[querygeneration] def renameColumns(
+                                              origOutput: Seq[NamedExpression],
+                                              alias: String
+                                            ): Seq[NamedExpression] = {
+
+    val col_names = Iterator.from(0).map(n => s"COL_$n")
+
+    origOutput.map { expr =>
+      val metadata = expr.metadata
+
+      val altName = s"""${alias}_${col_names.next()}"""
+
+      expr match {
+        case a@Alias(child: Expression, name: String) =>
+          Alias(child, altName)(a.exprId, Seq.empty[String], Some(metadata))
+        case _ =>
+          Alias(expr, altName)(expr.exprId, Seq.empty[String], Some(metadata))
+      }
+    }
+  }
+
+  private[querygeneration] final def wrap(name: String): String = {
+    name.toUpperCase
+  }
+
+  private[querygeneration] final def convertStatement(
+                                                       expression: Expression,
+                                                       fields: Seq[Attribute]
+                                                     ): RedshiftPushDownSqlStatement = {
+    (expression, fields) match {
+      case AggregationStatement(stmt) => stmt
+      case BasicStatement(stmt) => stmt
+      case BooleanStatement(stmt) => stmt
+      case DateStatement(stmt) => stmt
+      case MiscStatement(stmt) => stmt
+      case NumericStatement(stmt) => stmt
+      case StringStatement(stmt) => stmt
+      case WindowStatement(stmt) => stmt
+      case UnsupportedStatement(stmt) => stmt
+      // UnsupportedStatement must be the last CASE
+    }
+  }
+
+  private[querygeneration] final def convertStatements(
+                                                        fields: Seq[Attribute],
+                                                        expressions: Expression*
+                                                      ): RedshiftPushDownSqlStatement =
+    mkStatement(expressions.map(convertStatement(_, fields)), ",")
+
+  final def mkStatement(
+                         seq: Seq[RedshiftPushDownSqlStatement],
+                         delimiter: RedshiftPushDownSqlStatement
+                       ): RedshiftPushDownSqlStatement =
+    seq.foldLeft(new RedshiftPushDownSqlStatement()) {
+      case (left, stmt) =>
+        if (left.isEmpty) stmt else left + delimiter + stmt
+    }
+
+  final def mkStatement(seq: Seq[RedshiftPushDownSqlStatement],
+                        delimiter: String): RedshiftPushDownSqlStatement =
+    mkStatement(seq, ConstantString(delimiter) !)
+}

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
@@ -18,7 +18,6 @@ package io.github.spark_redshift_community.spark.redshift
 
 import java.io.{ByteArrayInputStream, OutputStreamWriter}
 import java.net.URI
-
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{BucketLifecycleConfiguration, S3Object, S3ObjectInputStream}
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule
@@ -28,7 +27,6 @@ import org.mockito.Matchers._
 import org.mockito.Mockito
 import org.mockito.Mockito.when
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.hadoop.fs.UnsupportedFileSystemException
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
@@ -38,6 +36,8 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
 
 /**
@@ -403,7 +403,8 @@ class RedshiftSourceSuite
       mockRedshift.jdbcWrapper,
       _ => mockS3Client,
       Parameters.mergeParameters(params),
-      userSchema = None)(testSqlContext)
+      userSchema = None,
+      new JDBCOptions(CaseInsensitiveMap(Map("aiq_testing"-> "true"))))(testSqlContext)
     relation.asInstanceOf[InsertableRelation].insert(expectedDataDF, overwrite = true)
 
     // Make sure we wrote the data out ready for Redshift load, in the expected formats.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.7-aiq2"
+version in ThisBuild := "5.0.7-aiq3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.7-aiq3"
+version in ThisBuild := "5.0.7-aiq4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.5-aiq1"
+version in ThisBuild := "5.0.7-aiq2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.7-aiq4"
+version in ThisBuild := "5.0.7-aiq6"


### PR DESCRIPTION
https://actioniq.atlassian.net/browse/EXE-1273

Move pushdown code to here, and add trace_id and partner name for every queries send to redshift.
Naming convention is something like JdbcWrapper to RedshiftJdbcPushdownWrapper, pushdownQuery to RedshiftPushdownQuery ... etc
Interesting changes are in RedshiftRelation.scala 😛 

Tests:
Tested in aiq55-v1 dev cluster

```
spark.read.format("io.github.spark_redshift_community.spark.redshift").option("url", jdbcUrl).option("dbtable", tableName).options(options).option("aiq_redshift_extra_pushdown", true).option("aiq_trace_id", "123").load()
```

test query [34000775](https://us-east-1.console.aws.amazon.com/redshiftv2/home?region=us-east-1#serverless-query?queryId=34000775&workgroup=test-hybridcompute)

[benchmark result](https://actioniq.atlassian.net/browse/EXE-1273?focusedCommentId=106550)

### Deploy Note
```
sbt publishM2
aws s3 sync ~/.m2/repository/io/github/spark-redshift-community/ s3://aiq-artifacts/releases/io/github/spark-redshift-community
```