### PR TITLE
[EXE-1528] Send jdbcOptions as MergedParameter to driver

### DIFF
--- a/src/it/scala/io/github/spark_redshift_community/spark/redshift/IntegrationSuiteBase.scala
+++ b/src/it/scala/io/github/spark_redshift_community/spark/redshift/IntegrationSuiteBase.scala
@@ -26,6 +26,8 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.types.StructType
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
 
+import io.github.spark_redshift_community.spark.redshift.Parameters.MergedParameters
+
 import scala.util.Random
 
 
@@ -62,6 +64,16 @@ trait IntegrationSuiteBase
     s"$AWS_REDSHIFT_JDBC_URL?user=$AWS_REDSHIFT_USER&password=$AWS_REDSHIFT_PASSWORD&ssl=true"
   }
 
+  protected def param: MergedParameters = {
+    MergedParameters(
+      Map(
+        "url" -> jdbcUrlNoUserPassword,
+        "user" -> AWS_REDSHIFT_USER,
+        "password" -> AWS_REDSHIFT_PASSWORD
+      )
+    )
+  }
+
   protected def jdbcUrlNoUserPassword: String = {
     s"$AWS_REDSHIFT_JDBC_URL?ssl=true"
   }
@@ -91,7 +103,7 @@ trait IntegrationSuiteBase
     sc.hadoopConfiguration.set("fs.s3n.awsSecretAccessKey", AWS_SECRET_ACCESS_KEY)
     sc.hadoopConfiguration.set("fs.s3a.access.key", AWS_ACCESS_KEY_ID)
     sc.hadoopConfiguration.set("fs.s3a.secret.key", AWS_SECRET_ACCESS_KEY)
-    conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl, None)
+    conn = DefaultJDBCWrapper.getConnector(param)
   }
 
   override def afterAll(): Unit = {

--- a/src/it/scala/io/github/spark_redshift_community/spark/redshift/PostgresDriverIntegrationSuite.scala
+++ b/src/it/scala/io/github/spark_redshift_community/spark/redshift/PostgresDriverIntegrationSuite.scala
@@ -30,7 +30,7 @@ class PostgresDriverIntegrationSuite extends IntegrationSuiteBase {
 
   // TODO (luca|issue #9) Fix tests when using postgresql driver
   ignore("postgresql driver takes precedence for jdbc:postgresql:// URIs") {
-    val conn = DefaultJDBCWrapper.getConnector(None, jdbcUrl, None)
+    val conn = DefaultJDBCWrapper.getConnector(param)
     try {
       assert(conn.getClass.getName === "org.postgresql.jdbc4.Jdbc4Connection")
     } finally {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
@@ -98,7 +98,7 @@ class DefaultSource(
     }
 
     def tableExists: Boolean = {
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
+      val conn = jdbcWrapper.getConnector(params)
       try {
         jdbcWrapper.tableExists(conn, table.toString)
       } finally {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
@@ -127,7 +127,7 @@ class DefaultSource(
     if (doSave) {
       val updatedParams = parameters.updated("overwrite", dropExisting.toString)
       new RedshiftWriter(jdbcWrapper, s3ClientFactory).saveToRedshift(
-        sqlContext, data, saveMode, Parameters.mergeParameters(updatedParams), jdbcOptions)
+        sqlContext, data, saveMode, Parameters.mergeParameters(updatedParams))
     }
 
     createRelation(sqlContext, parameters)

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
@@ -91,7 +91,6 @@ class DefaultSource(
       parameters: Map[String, String],
       data: DataFrame): BaseRelation = {
     val params = Parameters.mergeParameters(parameters)
-    val jdbcOptions = new JDBCOptions(CaseInsensitiveMap(parameters))
     val table = params.table.getOrElse {
       throw new IllegalArgumentException(
         "For save operations you must specify a Redshift table name with the 'dbtable' parameter")

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/DefaultSource.scala
@@ -98,7 +98,7 @@ class DefaultSource(
     }
 
     def tableExists: Boolean = {
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
+      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
       try {
         jdbcWrapper.tableExists(conn, table.toString)
       } finally {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
@@ -17,6 +17,8 @@
 
 package io.github.spark_redshift_community.spark.redshift
 
+import io.github.spark_redshift_community.spark.redshift.Parameters.MergedParameters
+
 import java.sql.{Connection, Driver, DriverManager, PreparedStatement, ResultSet, ResultSetMetaData, SQLException}
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
@@ -197,7 +199,7 @@ private[redshift] class JDBCWrapper {
   def getConnector(
       userProvidedDriverClass: Option[String],
       url: String,
-      jdbcOptions: JDBCOptions) : Connection = {
+      mergedParameters: MergedParameters) : Connection = {
     val subprotocol = url.stripPrefix("jdbc:").split(":")(0)
     val driverClass: String = getDriverClass(subprotocol, userProvidedDriverClass)
     DriverRegistry.register(driverClass)
@@ -222,7 +224,12 @@ private[redshift] class JDBCWrapper {
     }.getOrElse {
       throw new IllegalArgumentException(s"Did not find registered driver with class $driverClass")
     }
-    driver.connect(url, jdbcOptions.asConnectionProperties)
+    val properties = new Properties()
+    mergedParameters.parameters.foreach { case (key, value) =>
+      log.info(s"key: ${key} value ${value}")
+      properties.setProperty(key, value)
+    }
+    driver.connect(url, properties)
   }
 
   /**

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.Duration
 import scala.util.Try
 import scala.util.control.NonFatal
 import org.apache.spark.SPARK_VERSION
-import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions}
+import org.apache.spark.sql.execution.datasources.jdbc.DriverRegistry
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
@@ -196,10 +196,9 @@ private[redshift] class JDBCWrapper {
    *                                discover the appropriate driver class.
    * @param url the JDBC url to connect to.
    */
-  def getConnector(
-      userProvidedDriverClass: Option[String],
-      url: String,
-      mergedParameters: MergedParameters) : Connection = {
+  def getConnector(mergedParameters: MergedParameters) : Connection = {
+    val url = mergedParameters.jdbcUrl
+    val userProvidedDriverClass = mergedParameters.jdbcDriver
     val subprotocol = url.stripPrefix("jdbc:").split(":")(0)
     val driverClass: String = getDriverClass(subprotocol, userProvidedDriverClass)
     DriverRegistry.register(driverClass)

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
@@ -225,7 +225,6 @@ private[redshift] class JDBCWrapper {
     }
     val properties = new Properties()
     mergedParameters.parameters.foreach { case (key, value) =>
-      log.info(s"key: ${key} value ${value}")
       properties.setProperty(key, value)
     }
     driver.connect(url, properties)

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -63,7 +63,7 @@ private[redshift] case class RedshiftRelation(
     userSchema.getOrElse {
       val tableNameOrSubquery =
         params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
+      val conn = jdbcWrapper.getConnector(params)
       try {
         jdbcWrapper.resolveTable(conn, tableNameOrSubquery)
       } finally {
@@ -89,7 +89,7 @@ private[redshift] case class RedshiftRelation(
   }
 
   private def executeCountQuery(query: String): RDD[InternalRow] = {
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
+    val conn = jdbcWrapper.getConnector(params)
     val queryWithTag = RedshiftPushDownSqlStatement.appendTagsToQuery(jdbcOptions, query)
     try {
       val results = jdbcWrapper.executeQueryInterruptibly(conn.prepareStatement(queryWithTag))
@@ -116,7 +116,7 @@ private[redshift] case class RedshiftRelation(
     // Unload data from Redshift into a temporary directory in S3:
     val tempDir = params.createPerQueryTempDir()
     val unloadSql = buildUnloadStmt(query, tempDir, creds, params.sseKmsKey)
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
+    val conn = jdbcWrapper.getConnector(params)
     try {
       jdbcWrapper.executeInterruptibly(conn.prepareStatement(unloadSql))
     } finally {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -63,7 +63,7 @@ private[redshift] case class RedshiftRelation(
     userSchema.getOrElse {
       val tableNameOrSubquery =
         params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
+      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
       try {
         jdbcWrapper.resolveTable(conn, tableNameOrSubquery)
       } finally {
@@ -81,7 +81,7 @@ private[redshift] case class RedshiftRelation(
       SaveMode.Append
     }
     val writer = new RedshiftWriter(jdbcWrapper, s3ClientFactory)
-    writer.saveToRedshift(sqlContext, data, saveMode, params)
+    writer.saveToRedshift(sqlContext, data, saveMode, params, jdbcOptions)
   }
 
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {
@@ -89,7 +89,7 @@ private[redshift] case class RedshiftRelation(
   }
 
   private def executeCountQuery(query: String): RDD[InternalRow] = {
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
+    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
     val queryWithTag = RedshiftPushDownSqlStatement.appendTagsToQuery(jdbcOptions, query)
     try {
       val results = jdbcWrapper.executeQueryInterruptibly(conn.prepareStatement(queryWithTag))
@@ -116,7 +116,7 @@ private[redshift] case class RedshiftRelation(
     // Unload data from Redshift into a temporary directory in S3:
     val tempDir = params.createPerQueryTempDir()
     val unloadSql = buildUnloadStmt(query, tempDir, creds, params.sseKmsKey)
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
+    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
     try {
       jdbcWrapper.executeInterruptibly(conn.prepareStatement(unloadSql))
     } finally {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -63,7 +63,7 @@ private[redshift] case class RedshiftRelation(
     userSchema.getOrElse {
       val tableNameOrSubquery =
         params.query.map(q => s"($q)").orElse(params.table.map(_.toString)).get
-      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
+      val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
       try {
         jdbcWrapper.resolveTable(conn, tableNameOrSubquery)
       } finally {
@@ -89,7 +89,7 @@ private[redshift] case class RedshiftRelation(
   }
 
   private def executeCountQuery(query: String): RDD[InternalRow] = {
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
+    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
     val queryWithTag = RedshiftPushDownSqlStatement.appendTagsToQuery(jdbcOptions, query)
     try {
       val results = jdbcWrapper.executeQueryInterruptibly(conn.prepareStatement(queryWithTag))
@@ -116,7 +116,7 @@ private[redshift] case class RedshiftRelation(
     // Unload data from Redshift into a temporary directory in S3:
     val tempDir = params.createPerQueryTempDir()
     val unloadSql = buildUnloadStmt(query, tempDir, creds, params.sseKmsKey)
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
+    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
     try {
       jdbcWrapper.executeInterruptibly(conn.prepareStatement(unloadSql))
     } finally {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -81,7 +81,7 @@ private[redshift] case class RedshiftRelation(
       SaveMode.Append
     }
     val writer = new RedshiftWriter(jdbcWrapper, s3ClientFactory)
-    writer.saveToRedshift(sqlContext, data, saveMode, params, jdbcOptions)
+    writer.saveToRedshift(sqlContext, data, saveMode, params)
   }
 
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
@@ -18,13 +18,13 @@ package io.github.spark_redshift_community.spark.redshift
 
 import java.net.URI
 import java.sql.{Connection, Date, SQLException, Timestamp}
-
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 import io.github.spark_redshift_community.spark.redshift.Parameters.MergedParameters
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
 import org.slf4j.LoggerFactory
@@ -344,7 +344,8 @@ private[redshift] class RedshiftWriter(
       sqlContext: SQLContext,
       data: DataFrame,
       saveMode: SaveMode,
-      params: MergedParameters) : Unit = {
+      params: MergedParameters,
+      jdbcOptions: JDBCOptions) : Unit = {
     if (params.table.isEmpty) {
       throw new IllegalArgumentException(
         "For save operations you must specify a Redshift table name with the 'dbtable' parameter")
@@ -403,7 +404,7 @@ private[redshift] class RedshiftWriter(
       tempDir = params.createPerQueryTempDir(),
       tempFormat = params.tempFormat,
       nullString = params.nullString)
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params.credentials)
+    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
     conn.setAutoCommit(false)
     try {
       val table: TableName = params.table.get

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
@@ -344,8 +344,7 @@ private[redshift] class RedshiftWriter(
       sqlContext: SQLContext,
       data: DataFrame,
       saveMode: SaveMode,
-      params: MergedParameters,
-      jdbcOptions: JDBCOptions) : Unit = {
+      params: MergedParameters) : Unit = {
     if (params.table.isEmpty) {
       throw new IllegalArgumentException(
         "For save operations you must specify a Redshift table name with the 'dbtable' parameter")

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
@@ -404,7 +404,7 @@ private[redshift] class RedshiftWriter(
       tempDir = params.createPerQueryTempDir(),
       tempFormat = params.tempFormat,
       nullString = params.nullString)
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, jdbcOptions)
+    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
     conn.setAutoCommit(false)
     try {
       val table: TableName = params.table.get

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
@@ -403,7 +403,7 @@ private[redshift] class RedshiftWriter(
       tempDir = params.createPerQueryTempDir(),
       tempFormat = params.tempFormat,
       nullString = params.nullString)
-    val conn = jdbcWrapper.getConnector(params.jdbcDriver, params.jdbcUrl, params)
+    val conn = jdbcWrapper.getConnector(params)
     conn.setAutoCommit(false)
     try {
       val table: TableName = params.table.get

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
@@ -24,12 +24,10 @@ import io.github.spark_redshift_community.spark.redshift.Parameters.MergedParame
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
 import org.slf4j.LoggerFactory
 
-import scala.collection.mutable
 import scala.util.control.NonFatal
 
 /**

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/MockRedshift.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/MockRedshift.scala
@@ -16,8 +16,9 @@
 
 package io.github.spark_redshift_community.spark.redshift
 
-import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
+import io.github.spark_redshift_community.spark.redshift.Parameters.MergedParameters
 
+import java.sql.{Connection, PreparedStatement, ResultSet, SQLException}
 import org.apache.spark.sql.types.StructType
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -69,7 +70,7 @@ class MockRedshift(
   doAnswer(new Answer[Connection] {
       override def answer(invocation: InvocationOnMock): Connection = createMockConnection()
     }).when(jdbcWrapper)
-      .getConnector(any[Option[String]](), same(jdbcUrl), any[Option[(String, String)]]())
+      .getConnector(any[MergedParameters]())
 
   doAnswer(new Answer[Boolean] {
     override def answer(invocation: InvocationOnMock): Boolean = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.7-aiq12"
+version in ThisBuild := "5.0.7-aiq13"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.7-aiq6"
+version in ThisBuild := "5.0.7-aiq11"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.7-aiq11"
+version in ThisBuild := "5.0.7-aiq12"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.7-aiq13"
+version in ThisBuild := "5.0.7-aiq14"


### PR DESCRIPTION
https://actioniq.atlassian.net/browse/EXE-1528
Didn't send queryGroup to driver, details [here](https://github.com/ActionIQ/aiq/pull/45592#issuecomment-1526308915)
```
sc.setLogLevel("info")
val redshiftOpts = Map(
  "aws_iam_role" -> "arn:aws:iam::938824509083:role/journeys-redshift-dev-redshift-role",
  "tempDir" -> s"s3a://aiq-1d-expire-dev/redshift/109",
  "driver" -> "com.amazon.redshift.jdbc42.Driver",
  "dbtable" -> "qahybridredshift.rd_dim_item",
  "queryGroup" -> "123456678908",
  "aiq_partner" -> "partnerName",
  "ApplicationName" -> "appName",
  "password" -> "",
  "user" -> "admin",
  "url" -> "jdbc:redshift://test-hybridcompute.938824509083.us-east-1.redshift-serverless.amazonaws.com:5439/dev?"
)
spark.read.format("io.github.spark_redshift_community.spark.redshift").options(redshiftOpts).load().show()
```

Sending a query from spark-shell and see the query_label `select * from SYS_QUERY_HISTORY where query_label = '123456678908'

### Deploy Note
```
sbt publishM2       
aws s3 sync ~/.m2/repository/io/github/spark-redshift-community/ s3://aiq-artifacts/releases/io/github/spark-redshift-community
```